### PR TITLE
Fix deheader warnings

### DIFF
--- a/example/jsondump.c
+++ b/example/jsondump.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <string.h>
 #include <errno.h>
 #include "../jsmn.h"

--- a/example/simple.c
+++ b/example/simple.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "../jsmn.h"
 

--- a/jsmn.c
+++ b/jsmn.c
@@ -1,5 +1,3 @@
-#include <stdlib.h>
-
 #include "jsmn.h"
 
 /**


### PR DESCRIPTION
Prior to this commit the output of deheader was:

```
    remove <stdlib.h> from ./jsmn.c
    in ./example/jsondump.c, realloc() portability requires <unistd.h>.
    in ./example/simple.c, strtol() portability requires <stdlib.h>.
    saw 4 files, 16 includes, 1 removable
```
