### PR TITLE
First child, next sibling

### DIFF
--- a/jsmn.h
+++ b/jsmn.h
@@ -45,6 +45,10 @@ typedef struct {
 #ifdef JSMN_PARENT_LINKS
 	int parent;
 #endif
+#ifdef JSMN_FIRST_CHILD_NEXT_SIBLING
+    int first_child;
+    int next_sibling;
+#endif
 } jsmntok_t;
 
 /**


### PR DESCRIPTION
Hey, just wanted to share a small tweak to JSMN that I've been using to help with traversing the token tree. Following how things are done in JSMN_PARENT_LINKS, I've added JSMN_FIRST_CHILD_NEXT_SIBLING.

I use it to help with parsing jsonrpc requests. For example, if I have a json string like this:

{"jsonrpc":"2.0","method":"echo","params":["hello", "world"],"id":1}

... and want to get the value of "id", I iterate over the "first level" elements.

``` c++
jsmntok_t tokens[TOKENS_MAXSIZE];
jsmntok_t* value;

int self = tokens[0].first_child;
if (self == -1) {
    //error
}

do {
    if (strncmp("id", json_string + tokens[self].start, 
                        tokens[self].end - tokens[self].start) == 0)
    {
        value = (tokens[self].first_child == -1) 
                        ? NULL : &tokens[tokens[self].first_child];
    }
} while ( (self = tokens[self].next_sibling) != -1);
```

Would you be interested in this feature?
