### PR TITLE
tests: fix test_object JSMN_PRIMITIVE bug

### DIFF
--- a/test/tests.c
+++ b/test/tests.c
@@ -44,7 +44,7 @@ int test_object(void) {
 	check(parse("{\"a\": 0, \"b\": \"c\"}", 5, 5,
 				JSMN_OBJECT, -1, -1, 2,
 				JSMN_STRING, "a", 1,
-				JSMN_PRIMITIVE, 0,
+				JSMN_PRIMITIVE, "0",
 				JSMN_STRING, "b", 1,
 				JSMN_STRING, "c", 0));
 


### PR DESCRIPTION
Specify the argument after JSMN_PRIMITIVE as "0" instead of 0 so that weird things don't happen on OSX due to using it later with [`va_arg(..., char *)` in `vtokeq`](https://github.com/zserge/jsmn/blob/b77d84ba48e057aa464b6c6b6f6209e632918cb3/test/testutil.h#L20-L22).

I was able to reproduce the original bug and reduce it down to:

``` c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>
#include <stdarg.h>

#include "test.h"
#include "testutil.h"

int main(void) {
  check(parse("{\"a\": 0, \"b\": \"c\"}", 5, 5,
        JSMN_OBJECT, -1, -1, 2,
        JSMN_STRING, "a", 1,
        JSMN_PRIMITIVE, 0,
        JSMN_STRING, "b", 1,
        JSMN_STRING, "c", 0));
  printf("\nPASSED: %d\nFAILED: %d\n", test_passed, test_failed);
  return (test_failed > 0);
}
```

```
$ make test
cc   test/tests.c -o test/test_default
./test/test_default
make: *** [test_default] Segmentation fault: 11
```

^ and eventually found the `va_arg` usage.
## 

Resolves https://github.com/zserge/jsmn/issues/72.
