### PR TITLE
Fully validate JSON in JSMN_STRICT mode

### DIFF
--- a/jsmn.c
+++ b/jsmn.c
@@ -180,6 +180,8 @@ int jsmn_parse(jsmn_parser *parser, const char *js, size_t len,
 #ifdef JSMN_STRICT
 				if ((parser->state & 3) != EXPECTING_VALUE && parser->depth != 0)
 					return JSMN_ERROR_INVAL;
+                                if (parser->depth = UINT_MAX - 1)
+					return JSMN_ERROR_INVAL; /* Overflow! */
 				parser->depth++;
 				parser->is_in_array = c == '[';
 				parser->state = 4 |

--- a/jsmn.h
+++ b/jsmn.h
@@ -54,10 +54,11 @@ typedef struct {
 typedef struct {
 	unsigned int pos; /* offset in the JSON string */
 	unsigned int toknext; /* next token to allocate */
-	int toksuper; /* superior token node, e.g parent object or array */
+	unsigned int toksuper; /* superior token node, e.g parent object or array */
 #ifdef JSMN_STRICT
-        unsigned short state;
-        unsigned short is_in_array;
+	unsigned int depth;
+	unsigned short state;
+	unsigned short is_in_array;
 #endif
 } jsmn_parser;
 
@@ -72,6 +73,7 @@ void jsmn_init(jsmn_parser *parser);
  */
 int jsmn_parse(jsmn_parser *parser, const char *js, size_t len,
 		jsmntok_t *tokens, unsigned int num_tokens);
+
 
 #ifdef __cplusplus
 }

--- a/jsmn.h
+++ b/jsmn.h
@@ -55,6 +55,10 @@ typedef struct {
 	unsigned int pos; /* offset in the JSON string */
 	unsigned int toknext; /* next token to allocate */
 	int toksuper; /* superior token node, e.g parent object or array */
+#ifdef JSMN_STRICT
+        unsigned short state;
+        unsigned short is_in_array;
+#endif
 } jsmn_parser;
 
 /**

--- a/test/tests.c
+++ b/test/tests.c
@@ -54,21 +54,22 @@ int test_object(void) {
 	check(parse("{\"a\": {2}}", JSMN_ERROR_INVAL, 3));
 	check(parse("{\"a\": {2: 3}}", JSMN_ERROR_INVAL, 3));
 	check(parse("{\"a\": {\"a\": 2 3}}", JSMN_ERROR_INVAL, 5));
-	/* FIXME */
-	/*check(parse("{\"a\"}", JSMN_ERROR_INVAL, 2));*/
-	/*check(parse("{\"a\": 1, \"b\"}", JSMN_ERROR_INVAL, 4));*/
-	/*check(parse("{\"a\",\"b\":1}", JSMN_ERROR_INVAL, 4));*/
-	/*check(parse("{\"a\":1,}", JSMN_ERROR_INVAL, 4));*/
-	/*check(parse("{\"a\":\"b\":\"c\"}", JSMN_ERROR_INVAL, 4));*/
-	/*check(parse("{,}", JSMN_ERROR_INVAL, 4));*/
+	check(parse("{\"a\"}", JSMN_ERROR_INVAL, 2));
+	check(parse("{\"a\": 1, \"b\"}", JSMN_ERROR_INVAL, 4));
+	check(parse("{\"a\",\"b\":1}", JSMN_ERROR_INVAL, 4));
+	check(parse("{\"a\":1,}", JSMN_ERROR_INVAL, 4));
+	check(parse("{\"a\":\"b\":\"c\"}", JSMN_ERROR_INVAL, 4));
+	check(parse("{,}", JSMN_ERROR_INVAL, 4));
 #endif
 	return 0;
 }
 
 int test_array(void) {
 	/* FIXME */
-	/*check(parse("[10}", JSMN_ERROR_INVAL, 3));*/
-	/*check(parse("[1,,3]", JSMN_ERROR_INVAL, 3)*/
+#ifdef JSMN_STRING
+	check(parse("[10}", JSMN_ERROR_INVAL, 3));
+	check(parse("[1,,3]", JSMN_ERROR_INVAL, 3)
+#endif
 	check(parse("[10]", 2, 2,
 				JSMN_ARRAY, -1, -1, 1,
 				JSMN_PRIMITIVE, "10"));
@@ -146,8 +147,13 @@ int test_partial_string(void) {
 	jsmntok_t tok[5];
 	const char *js = "{\"x\": \"va\\\\ue\", \"y\": \"value y\"}";
 
+#ifndef JSMN_STRICT
 	jsmn_init(&p);
+#endif
 	for (i = 1; i <= strlen(js); i++) {
+#ifdef JSMN_STRICT
+		jsmn_init(&p);
+#endif
 		r = jsmn_parse(&p, js, i, tok, sizeof(tok)/sizeof(tok[0]));
 		if (i == strlen(js)) {
 			check(r == 5);
@@ -172,8 +178,13 @@ int test_partial_array(void) {
 	jsmntok_t tok[10];
 	const char *js = "[ 1, true, [123, \"hello\"]]";
 
+#ifndef JSMN_STRICT
 	jsmn_init(&p);
+#endif
 	for (i = 1; i <= strlen(js); i++) {
+#ifdef JSMN_STRICT
+		jsmn_init(&p);
+#endif
 		r = jsmn_parse(&p, js, i, tok, sizeof(tok)/sizeof(tok[0]));
 		if (i == strlen(js)) {
 			check(r == 6);
@@ -209,7 +220,9 @@ int test_array_nomem(void) {
 		check(r == JSMN_ERROR_NOMEM);
 
 		memcpy(toklarge, toksmall, sizeof(toksmall));
-
+#ifdef JSMN_STRICT
+		jsmn_init(&p);
+#endif
 		r = jsmn_parse(&p, js, strlen(js), toklarge, 10);
 		check(r >= 0);
 		check(tokeq(js, toklarge, 4,
@@ -270,7 +283,14 @@ int test_issue_27(void) {
 	check(parse(js, JSMN_ERROR_PART, 8));
 	return 0;
 }
-
+#if 0
+int test_incremental_parsing(void) {
+	const char *js = "{ \"nam";
+	jsmn_parser p;
+	jsmn_init(&p);
+	jsmntok_t tokens[10];
+	int r = jsmn_parse
+#endif
 int test_input_length(void) {
 	const char *js;
 	int r;

--- a/test/tests.c
+++ b/test/tests.c
@@ -338,8 +338,8 @@ int test_count(void) {
 
 
 int test_nonstrict(void) {
-#ifndef JSMN_STRICT
 	const char *js;
+#ifndef JSMN_STRICT
 	js = "a: 0garbage";
 	check(parse(js, 2, 2,
 				JSMN_PRIMITIVE, "a",
@@ -353,6 +353,11 @@ int test_nonstrict(void) {
 				JSMN_PRIMITIVE, "Sep",
 				JSMN_PRIMITIVE, "Year",
 				JSMN_PRIMITIVE, "12"));
+#else
+        js = "{:}";
+	check(parse(js, JSMN_ERROR_INVAL, 1));
+	js = "{,}";
+	check(parse(js, JSMN_ERROR_INVAL, 1));
 #endif
 	return 0;
 }


### PR DESCRIPTION
This PR adds full validation of JSON in JSMN_STRICT mode.  This is done by keeping additional state to indicate what the parser is currently expecting.

As a side effect, the ABI with JSMN_STRICT is no longer the same as that when JSMN_STRICT is not defined.