### PR TITLE
Should allow primitive at root to comply RFC

### DIFF
--- a/test/tests.c
+++ b/test/tests.c
@@ -340,7 +340,7 @@ int test_root(void) {
 	const char *js;
 	js = "\"hello\"";
 	check(parse(js, 1, 1,
-				JSMN_STRING, "hello"));
+				JSMN_STRING, "hello", 0));
 	js = "null";
 	check(parse(js, 1, 1,
 				JSMN_PRIMITIVE, "null"));

--- a/test/tests.c
+++ b/test/tests.c
@@ -336,6 +336,23 @@ int test_object_key(void) {
   return 0;
 }
 
+int test_root(void) {
+	const char *js;
+	js = "\"hello\"";
+	check(parse(js, 1, 1,
+				JSMN_STRING, "hello"));
+	js = "null";
+	check(parse(js, 1, 1,
+				JSMN_PRIMITIVE, "null"));
+	js = "1";
+	check(parse(js, 1, 1,
+				JSMN_PRIMITIVE, "1"));
+	js = "false";
+	check(parse(js, 1, 1,
+				JSMN_PRIMITIVE, "false"));
+	return 0;
+}
+
 int main(void) {
   test(test_empty, "test for a empty JSON objects/arrays");
   test(test_object, "test for a JSON objects");
@@ -354,6 +371,7 @@ int main(void) {
   test(test_nonstrict, "test for non-strict mode");
   test(test_unmatched_brackets, "test for unmatched brackets");
   test(test_object_key, "test for key type");
+  test(test_root, "test for values at root");
   printf("\nPASSED: %d\nFAILED: %d\n", test_passed, test_failed);
   return (test_failed > 0);
 }


### PR DESCRIPTION
Current jsmn disallows only a primitive at root.  But [RFC7159](https://tools.ietf.org/html/rfc7159)  allows that like followings:

> JSON-text = ws value ws
> (snip)
>  value = false / null / true / object / array / number / string

So I think it should allow this even in JSMN_STRICT case.