### PR TITLE
Handle numeric primitives that start with '.' or '+'

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ first character:
 
 * <code>'t', 'f'</code> - boolean 
 * <code>'n'</code> - null
-* <code>'-', '0'..'9'</code> - number
+* <code>'-', '+', '.', '0'..'9'</code> - number
 
 Token is an object of `jsmntok_t` type:
 

--- a/jsmn.c
+++ b/jsmn.c
@@ -260,8 +260,9 @@ int jsmn_parse(jsmn_parser *parser, const char *js, size_t len,
 				break;
 #ifdef JSMN_STRICT
 			/* In strict mode primitives are: numbers and booleans */
-			case '-': case '0': case '1' : case '2': case '3' : case '4':
-			case '5': case '6': case '7' : case '8': case '9':
+			case '-': case '+': case '.':
+                        case '0': case '1': case '2': case '3' : case '4':
+			case '5': case '6': case '7': case '8': case '9' :
 			case 't': case 'f': case 'n' :
 				/* And they must not be keys of the object */
 				if (tokens != NULL && parser->toksuper != -1) {

--- a/test/tests.c
+++ b/test/tests.c
@@ -99,6 +99,14 @@ int test_primitive(void) {
 				JSMN_OBJECT, -1, -1, 1,
 				JSMN_STRING, "floatVar", 1,
 				JSMN_PRIMITIVE, "12.345"));
+	check(parse("{\"floatVarDot\" : .345}", 3, 3,
+				JSMN_OBJECT, -1, -1, 1,
+				JSMN_STRING, "floatVarDot", 1,
+				JSMN_PRIMITIVE, ".345"));
+	check(parse("{\"floatVarPlus\" : +12.345}", 3, 3,
+				JSMN_OBJECT, -1, -1, 1,
+				JSMN_STRING, "floatVarPlus", 1,
+				JSMN_PRIMITIVE, "+12.345"));
 	return 0;
 }
 


### PR DESCRIPTION
.345 and +12.345 are both valid floating point primitives.

Those cases are now tested in this pull request's test/tests.c.

Those tests fail if this pull request's changes to jsmn.c are not implemented, because the existing jsmn.c recognizes neither '+' nor '.' as the first character of a primitive.

I also updated the note regarding the type of primitives in README.md.

[eta:  fixed typo]