### PR TITLE
Btc/typos and more - clean up Makefile; add new example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+jsmndump_example
+jsmndump_strict_example
+jsondump_example
+jsondump_strict_example
+libjsmn.a
+libjsmn_strict.a
+simple_example
+simple_strict_example
+test/test_default
+test/test_links
+test/test_strict
+test/test_strict_links

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test/test_default
 test/test_links
 test/test_strict
 test/test_strict_links
+example/*.json

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ TESTS=test_default test_strict test_links test_strict_links
 
 all: libjsmn.a libjsmn_strict.a
 
+allall: clean all test examples strict_examples
+
 lib%.a: %.o
 	$(AR) rc $@ $^
 

--- a/example/buffer_file.c
+++ b/example/buffer_file.c
@@ -1,0 +1,239 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "buffer_file.h"
+
+
+/***********************************************************************
+ * Free pBuffile structure plus  data
+ * - *pBuf_len, IFF p_Buf_len is not null, will contain length of data
+ * - If pBuf_len is null (zero) just discard the data and free the pointer
+ */
+uint8_t* buffile_free(pBUFFILE pBuffile, size_t *pBuf_len) {
+uint8_t* pRtn_data = 0;
+
+  /* Assume failure:  return zero length and zero pointer */
+  if (pBuf_len) *pBuf_len = 0;
+  if (!pBuffile) return pRtn_data;
+
+  if (!pBuf_len && pBuffile->data) {
+    /* Free buffer if data length is not requested */
+    free(pBuffile->data);
+  } else if (pBuf_len) {
+    /* Save data and pointer if data length is requested */
+    pRtn_data = pBuffile->data;
+    *pBuf_len = pBuffile->len;
+  }
+  /* Free the BUFFILE structure */
+  if (pBuffile->malloced) { free(pBuffile); }
+  return pRtn_data;
+}
+
+
+/***********************************************************************
+ * Initialize a BUFFILE, pointed to by pBuffile
+ * - The caller sets malloced to non-zero if pBuffile is from a
+ *   malloc or realloc or calloc call.
+ */
+void buffile_init(pBUFFILE pBuffile, int malloced) {
+  if (!pBuffile) return;
+  pBuffile->malloced = malloced;
+  pBuffile->data = 0;
+  pBuffile->len = 0;
+  pBuffile->limit = 0;
+  return;
+}
+
+
+/***********************************************************************
+ * Add [to_add] chars to BUFFILE pointed to by pBuffile
+ * - Return pBuffile
+ * - Allocate BUFFILE and data if pBuffile is null
+ */
+pBUFFILE buffile_size(pBUFFILE pBuffile, size_t to_add) {
+size_t new_limit;
+
+  /* Allocate BUFFILE and data if pBuffile is null */
+  if (!pBuffile) {
+    pBuffile = malloc(sizeof(*pBuffile));
+    if (!pBuffile) return pBuffile;
+    buffile_init(pBuffile, 1);
+  }
+
+  /* Calculate new limit, allow one extra char for null terminator */
+  new_limit = pBuffile->len + to_add + 1;
+
+  if (new_limit > BUFFILE_UPPER_LIMIT) {
+    fprintf(stderr
+           , "buffile_size():  new limit (%lu) exceeds maximum limit (%lu)\n"
+           , (unsigned long) new_limit
+           , (unsigned long) BUFFILE_UPPER_LIMIT
+           );
+  }
+
+  /* Re-allocate data if limit will increase */
+  if (new_limit > pBuffile->limit) {
+  uint8_t* new_data = new_limit > BUFFILE_UPPER_LIMIT ? 0 : realloc(pBuffile->data, new_limit);
+    if (!new_data) {
+      /* Free BUFFILE structure and allocated data if realloc failed */
+      buffile_free(pBuffile, 0);
+      return 0;
+    }
+    /* Update BUFFILE data pointer and limit */
+    pBuffile->data = new_data;
+    pBuffile->limit = new_limit;
+    /* Put null terminator at limit */
+    new_data[pBuffile->limit-1] = '\0';
+  }
+  return pBuffile;
+}
+
+
+/***********************************************************************
+ * Concatenate buffer data (read from file) to pBuffile->data buffer
+ * - Return pointer to BUFFILE structure
+ * - Return null on failure
+ */
+pBUFFILE buffile_write(void* pVoidBuffile, size_t memb_size, size_t n_memb, void* pSource) {
+pBUFFILE pBuffile = (pBUFFILE) pVoidBuffile;
+size_t to_add = memb_size * n_memb;
+
+  /* Return BUFFILE pointer pFuffiles if source pointer is null, or if
+   * length of buffer data at pSource is non-positive
+   */
+  if (!pSource) return pBuffile;
+  if (to_add < 1) return pBuffile;
+
+  /* Increase BUFFILE data allocation; return null on failure */
+  if (!(pBuffile = buffile_size(pBuffile, to_add))) return 0;
+
+  /* Copy data from pSource to BUFFILE buffer pointer,
+   * update BUFFILE length
+   */
+  memcpy(pBuffile->data + pBuffile->len, pSource, to_add);
+  pBuffile->len += to_add;
+
+  /* Return BUFFILE pointer */
+  return pBuffile;
+}
+
+
+/***********************************************************************
+ * Read from file named filename into data buffer, return pointer to buffer
+ * and set *pBuf_len to buffer length
+ * ***N.B. If calling with a non-zero pBuffile pointer, call
+ *           buffile_init(pBuffile, malloced)
+ *         first
+ */
+uint8_t* buffile_file_to_puint8(char* filename, size_t* pBuf_len, pBUFFILE pBuffile) {
+FILE* pFile = filename ? (strcmp(filename,"-") ? fopen(filename,"rb") : stdin) : 0;
+char read_buffer[BUFSIZ];
+size_t n_read;
+
+  if (!pFile) return 0;
+
+  while (pBuf_len) {
+
+    /* Read next chunk; check for error */
+    n_read = fread(read_buffer, 1, sizeof(read_buffer), pFile);
+    if (ferror(pFile)) { pBuf_len = 0; break; }
+
+    /* Check for [no more data in file && EOF] */
+    if (!n_read && feof(pFile)) { break; }
+
+    /* Append chunk to pBuffile data; break on failure */
+    if (!(pBuffile = buffile_write(pBuffile, 1, n_read, read_buffer))) { pBuf_len = 0; break; };
+  }
+
+  if (pFile != stdin) fclose(pFile);
+
+  return buffile_free(pBuffile, pBuf_len);
+}
+/***********************************************************************
+ * End of buffer_file library
+ **********************************************************************/
+
+
+#ifdef DO_MAIN
+/***********************************************************************
+ * Test code
+ * - Read file into buffer
+ * - Compare buffer contents and length to file
+ *
+ * Build:  gcc -DDO_MAIN -o test_buffer_file buffer_file.c
+ *
+ * Run (BASH):  ./test_buffer_file && echo success || echo failure
+ */
+int
+main(int argc, char** argv) {
+char* filename = argc > 1 ? argv[1] : "buffer_file.h";
+size_t buf_len = 0;
+char oneline[1024];
+uint8_t* pData = buffile_file_to_puint8(filename, &buf_len, 0);
+uint8_t* pData2;
+uint8_t* buf_len2;
+pBUFFILE localBuffile;
+FILE* fIn;
+size_t iOffset;
+
+  buffile_init(&localBuffile, 0);
+  pData2 = buffile_file_to_puint8(filename, &buf_len2, &localBuffile);
+
+# define RTN \
+  if (pData) { free(pData); } \
+  if (pData2) { free(pData2); } \
+  if (fIn) { fclose(fIn); } \
+  return
+
+  /* Open file */
+  fIn = fopen(filename,"rb");
+  if (!fIn) { RTN -1; }
+
+  /* Fail if buffered data do not exist ... */
+  if (!pData || !buf_len || !pData2 || !buf_len2) {
+    /* ... unless file is empty */
+    if (EOF == fgetc(fIn)) { RTN 0; }
+    RTN 1;
+  }
+
+  /* Fail if two methods give different lengths */
+  if (buf_len != buf_len2) {
+      fprintf(stderr,"Per-method length mismatch [%ud != %ud]\n"
+             , buf_len, buf_len2
+             );
+  }
+
+  /* Loop over characters in buffered data, reading characters in parallel
+   * from the file, and compare them
+   */
+  for (iOffset=0; iOffset < buf_len; ++iOffset) {
+  int next_char;
+    if (EOF == (next_char=fgetc(fIn))) {
+      /* If fgetc returns EOF, the file ended early */
+      fprintf(stderr,"Early EOF\n");
+      RTN 1;
+    }
+    if (next_char != pData[iOffset] || next_char != pData2[iOffset]) {
+      /* If fgets returns a character different than what is in the buffer,
+       * then there is a mismatch
+       */
+      fprintf(stderr,"Mismatch at offset %ld [%d != %ud || %d != %ud]\n"
+             , (long)iOffset
+             , next_char, pData[iOffset]
+             , next_char, pData2[iOffset]
+             );
+      RTN 2;;
+    }
+  }
+  /* If the file matched the buffer through buf_len fgetc calls, but the
+   * next value returned by fgetc is not EOF, then the file has more
+   * characters than the buffer
+   */
+  if (iOffset == buf_len) {
+    if (EOF != fgetc(fIn)) { fprintf(stderr, "Late EOF\n"); RTN 3; }
+  } else {
+  }
+  /* Success:  file and buffer match in both content and length */
+  RTN 0;
+}
+#endif // DO_MAIN

--- a/example/buffer_file.h
+++ b/example/buffer_file.h
@@ -1,0 +1,22 @@
+#ifndef __BUFFER_FILE__
+#define __BUFFER_FILE__
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef struct BUFFILEstr {
+  int malloced;
+  uint8_t* data;
+  size_t len;
+  size_t limit;
+} *pBUFFILE, **ppBUFFILE, BUFFILE;
+
+uint8_t* buffile_free(pBUFFILE pBuffile, size_t* pBuf_len);
+void buffile_init(pBUFFILE pBuffile, int malloced);
+pBUFFILE buffile_size(pBUFFILE pBuffile, size_t to_add);
+pBUFFILE buffile_write(void* pVoidBuffile, size_t memb_size, size_t n_memb, void* pSource);
+uint8_t* buffile_file_to_puint8(char* filename, size_t* pBuf_len, pBUFFILE pBuffile);
+
+/* Set upper limit for buffer size add 100MBi */
+#define BUFFILE_UPPER_LIMIT ((size_t)100000000 )
+
+#endif // __BUFFER_FILE__

--- a/example/jsmndump.c
+++ b/example/jsmndump.c
@@ -1,30 +1,29 @@
+/***********************************************************************
+ * An example of reading JSON from stdin or filename, storing contents in
+ * a buffer, parsing the buffer, and thenprinting its content * to stdout.
+ * The output contains only primitives and the lengths of any arrays,
+ * preceded by their Javascript-ish name; the name starts with "json"
+ */
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
 #include "../jsmn.h"
+#include "buffer_file.c"
 
-/* Function realloc_it() is a wrapper function for standard realloc()
- * with one difference - it frees old memory pointer in case of realloc
- * failure. Thus, DO NOT use old data pointer in anyway after call to
- * realloc_it(). If your code has some kind of fallback algorithm if
- * memory can't be re-allocated - use standard realloc() instead.
- */
-static inline void *realloc_it(void *ptrmem, size_t size) {
-  void *p = realloc(ptrmem, size);
-  if (!p)  {
-    if (ptrmem) { free (ptrmem); }
-    fprintf(stderr, "realloc(): errno=%d\n", errno);
-  }
-  return p;
-}
 
-/* An example of reading JSON from stdin or file and printing its content
- * to stdout.  The output contains only primitives and the lengths of any
- * arrays, preceded by their name; the name starts with "json"
+/***********************************************************************
+ * dump(...) - recursive printer of JSON primitives that walks though
+ *             JSMN tokens
+ * Arguments:
+ *   js - pointer to memory buffer with JSON
+ *   t - pointer JSMN tokens; t[I].start and t[I].end are indices into js
+ *   count - number of tokens remaining
+ *   indent - indentation level
+ *   idpfx - name of the object or array container
  */
-static int dump(const char *js, jsmntok_t *t, size_t count, int indent, char* idpfx) {
+static int dump(const uint8_t* js, jsmntok_t *t, size_t count, int indent, char idpfx[BUFSIZ]) {
 int idpfxpos = idpfx ? strlen(idpfx) : 0;
 char* idpfxend = idpfx + idpfxpos;
 int i, j, k;
@@ -42,14 +41,12 @@ int idOk;
 
   } else if (t->type == JSMN_OBJECT) {
     for (j = i = 0; i < t->size; i++) {
+      /* Append object Javascript-ish name to idpfx buffer,
+       * IFF it will not overflow idbpx
+       */
       idOk = idpfx && ((idpfxpos + 1 + (t[1+j].end - t[1+j].start)) < BUFSIZ);
-#     if 0
-      if (t[1+j].type != JSMN_STRING) {
-        fprintf(stderr,"ERROR(name is not string)\n");
-        return 0;
-      }
-#     endif
       if (idOk) { sprintf(idpfxend, ".%.*s", t[1+j].end - t[1+j].start, js+t[1+j].start); }
+      /* Process member name */
       j += dump(js, t+1+j, count-j, indent+1, (char*) 0);
       j += dump(js, t+1+j, count-j, indent+1, idOk ? idpfx : (char*) 0);
     }
@@ -73,59 +70,47 @@ int idOk;
   return 0;
 }
 
+
+/***********************************************************************
+ * Main program:  read JSON file into memory; parse JSON; dump primitives
+ */
 int main(int argc, char** argv) {
 int r;
-int eof_expected = 0;
-char *js = NULL;
 size_t jslen = 0;
-char buf[BUFSIZ];
+char* filename = argc > 1 ? argv[1] : "-";
+uint8_t* js = (uint8_t*) buffile_file_to_puint8(filename, &jslen, 0);
 char idpfx[BUFSIZ] = { "json" };
-FILE *fIn = argc>1 ? fopen(argv[1],"rb") : stdin;
 jsmn_parser p;
-jsmntok_t *tok;
 size_t tokcount = 64;
+jsmntok_t* tok = realloc(0, sizeof(jsmntok_t) * tokcount);
 int rtn = 3;
 
-# define BRK(FPARGS, RTN) fprintf FPARGS; rtn = RTN; break
+# define BRK(FPARGS, RTN) fprintf FPARGS; rtn = RTN
 
   /* Initialize parser; allocate some tokens as a start */
   jsmn_init(&p);
-  tok = realloc_it(0, sizeof(jsmntok_t) * tokcount);
 
-  while (tok && fIn) {
-
-    /* Read next chunk; check for error; check for EOF */
-    r = fread(buf, 1, sizeof(buf), fIn);
-    if (ferror(fIn)) { BRK((stderr, "fread(): %d, errno=%d\n", r, errno), 1); }
-    if (r==0 && feof(fIn)) {
-      if (eof_expected) { BRK( , EXIT_SUCCESS); }
-      BRK((stderr, "fread(): unexpected EOF\n"), 2);
-    }
-
-    /* Append chunk to json string <js>, allocating js string as needed */
-    if (r > 0) {
-      if ( !(js = realloc_it(js, jslen + r + 1)) ) { BRK( , 3); }
-      strncpy(js + jslen, buf, r);
-      jslen += r;
-      js[jslen] = '\0';
-    }
-
-    /* Parse JSON, re-allocating double the # of token structs as needed */
-    while (tok && JSMN_ERROR_NOMEM == (r=jsmn_parse(&p, js, jslen, tok, tokcount))) {
-      tok = realloc_it(tok, sizeof(jsmntok_t) * (tokcount <<= 1));
-    }
-    if (!tok) { BRK( , 3); }
-    if (r == JSMN_ERROR_INVAL) { BRK((stderr, "jsmn_parse() error\n"), 4); }
-    if (r == JSMN_ERROR_PART) { continue; }  /* Expect more JSON data */
-    if (r > -1) { eof_expected = 1; }         /* Completed JSON parse */
+  /* Parse JSON, re-allocating double the # of token structs as needed */
+  while (js && tok && JSMN_ERROR_NOMEM == (r=jsmn_parse(&p, js, jslen, tok, tokcount))) {
+  jsmntok_t *old_tok;
+    old_tok = tok;
+    tok = realloc(old_tok, sizeof(jsmntok_t) * (tokcount <<= 1));
+    if (!tok) { free(old_tok); break; }
   }
 
-  /* Dump token contents if  parse was successful*/
+  if (!js) { BRK((stderr, "buffile_file_to_puint8(...) failed to read file into memory buffer\n"), 1); }
+  else if (!tok) { BRK((stderr, "realloc() failed to allocation tokens\n"), 2); }
+  else if (r == JSMN_ERROR_INVAL) { BRK((stderr, "jsmn_parse() error e.g. invalid character\n"), 3); }
+  else if (r == JSMN_ERROR_PART) { BRK((stderr, "jsmn_parse() error; incomplete JSON\n"), 4); }
+  else if (r == 0) { BRK((stderr, "jsmn_parse() error; possible empty JSON file\n"), 4); }
+  else if (r > 0) { BRK( , EXIT_SUCCESS); }
+  else { BRK((stderr, "jsmn_parse() unknown error\n"), 5); }
+
+  /* Dump token contents IFF parse was successful*/
   if (rtn == EXIT_SUCCESS) { dump(js, tok, p.toknext, 0, idpfx); }
 
   /* Clean up and return */
   if (tok) free(tok);
   if (js) free(js);
-  if (fIn && fIn != stdin) { fclose(fIn); }
   return rtn;
 }

--- a/example/jsmndump.c
+++ b/example/jsmndump.c
@@ -1,0 +1,131 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include "../jsmn.h"
+
+/* Function realloc_it() is a wrapper function for standard realloc()
+ * with one difference - it frees old memory pointer in case of realloc
+ * failure. Thus, DO NOT use old data pointer in anyway after call to
+ * realloc_it(). If your code has some kind of fallback algorithm if
+ * memory can't be re-allocated - use standard realloc() instead.
+ */
+static inline void *realloc_it(void *ptrmem, size_t size) {
+  void *p = realloc(ptrmem, size);
+  if (!p)  {
+    if (ptrmem) { free (ptrmem); }
+    fprintf(stderr, "realloc(): errno=%d\n", errno);
+  }
+  return p;
+}
+
+/* An example of reading JSON from stdin or file and printing its content
+ * to stdout.  The output contains only primitives and the lengths of any
+ * arrays, preceded by their name; the name starts with "json"
+ */
+static int dump(const char *js, jsmntok_t *t, size_t count, int indent, char* idpfx) {
+int idpfxpos = idpfx ? strlen(idpfx) : 0;
+char* idpfxend = idpfx + idpfxpos;
+int i, j, k;
+int idOk;
+
+  if (count == 0) { return 0; }
+
+  if (t->type == JSMN_PRIMITIVE) {
+    if (idpfx) printf("%s  %.*s\n", idpfx, t->end - t->start, js+t->start);
+    return 1;
+
+  } else if (t->type == JSMN_STRING) {
+    if (idpfx) printf("%s  '%.*s'\n", idpfx, t->end - t->start, js+t->start);
+    return 1;
+
+  } else if (t->type == JSMN_OBJECT) {
+    for (j = i = 0; i < t->size; i++) {
+      idOk = idpfx && ((idpfxpos + 1 + (t[1+j].end - t[1+j].start)) < BUFSIZ);
+#     if 0
+      if (t[1+j].type != JSMN_STRING) {
+        fprintf(stderr,"ERROR(name is not string)\n");
+        return 0;
+      }
+#     endif
+      if (idOk) { sprintf(idpfxend, ".%.*s", t[1+j].end - t[1+j].start, js+t[1+j].start); }
+      j += dump(js, t+1+j, count-j, indent+1, (char*) 0);
+      j += dump(js, t+1+j, count-j, indent+1, idOk ? idpfx : (char*) 0);
+    }
+    if (idpfx) { *idpfxend = '\0'; }
+    return j+1;
+
+  } else if (t->type == JSMN_ARRAY) {
+  char sfx[30];
+    for (j = i = 0; i < t->size; i++) {
+      sprintf(sfx, "[%d]", i);
+      idOk = idpfx && ((idpfxpos + strlen(sfx) < BUFSIZ));
+      if (idOk) { sprintf(idpfxend, "%s", sfx); }
+      j += dump(js, t+1+j, count-j, indent+1, idOk ? idpfx : (char*) 0);
+    }
+    if (idpfx) {
+      *idpfxend = '\0';
+      printf("%s.length  %d\n", idpfx, i);
+    }
+    return j+1;
+  }
+  return 0;
+}
+
+int main(int argc, char** argv) {
+int r;
+int eof_expected = 0;
+char *js = NULL;
+size_t jslen = 0;
+char buf[BUFSIZ];
+char idpfx[BUFSIZ] = { "json" };
+FILE *fIn = argc>1 ? fopen(argv[1],"rb") : stdin;
+jsmn_parser p;
+jsmntok_t *tok;
+size_t tokcount = 64;
+int rtn = 3;
+
+# define BRK(FPARGS, RTN) fprintf FPARGS; rtn = RTN; break
+
+  /* Initialize parser; allocate some tokens as a start */
+  jsmn_init(&p);
+  tok = realloc_it(0, sizeof(jsmntok_t) * tokcount);
+
+  while (tok && fIn) {
+
+    /* Read next chunk; check for error; check for EOF */
+    r = fread(buf, 1, sizeof(buf), fIn);
+    if (ferror(fIn)) { BRK((stderr, "fread(): %d, errno=%d\n", r, errno), 1); }
+    if (r==0 && feof(fIn)) {
+      if (eof_expected) { BRK( , EXIT_SUCCESS); }
+      BRK((stderr, "fread(): unexpected EOF\n"), 2);
+    }
+
+    /* Append chunk to json string <js>, allocating js string as needed */
+    if (r > 0) {
+      if ( !(js = realloc_it(js, jslen + r + 1)) ) { BRK( , 3); }
+      strncpy(js + jslen, buf, r);
+      jslen += r;
+      js[jslen] = '\0';
+    }
+
+    /* Parse JSON, re-allocating double the # of token structs as needed */
+    while (tok && JSMN_ERROR_NOMEM == (r=jsmn_parse(&p, js, jslen, tok, tokcount))) {
+      tok = realloc_it(tok, sizeof(jsmntok_t) * (tokcount <<= 1));
+    }
+    if (!tok) { BRK( , 3); }
+    if (r == JSMN_ERROR_INVAL) { BRK((stderr, "jsmn_parse() error\n"), 4); }
+    if (r == JSMN_ERROR_PART) { continue; }  /* Expect more JSON data */
+    if (r > -1) { eof_expected = 1; }         /* Completed JSON parse */
+  }
+
+  /* Dump token contents if  parse was successful*/
+  if (rtn == EXIT_SUCCESS) { dump(js, tok, p.toknext, 0, idpfx); }
+
+  /* Clean up and return */
+  if (tok) free(tok);
+  if (js) free(js);
+  if (fIn && fIn != stdin) { fclose(fIn); }
+  return rtn;
+}


### PR DESCRIPTION
    Makefile
    
    - Use make variables to define targets
    - Remove test executables in [make clean]
    - Make strict library libjsmn_strict.a and other products
    - Give examples consistent names
      - simple => simple_example (no change)
      - jsondump => jsondump_example (instead of jsondump)
    
    examples/jsmndump.c
    
    - New example code
    - Similar to jsondump
    - Outputs JS-ish names for primitives, plus array lengths
