### PR TITLE
Disallow using an object or an array as a name of an object member.

### DIFF
--- a/jsmn.c
+++ b/jsmn.c
@@ -170,7 +170,14 @@ int jsmn_parse(jsmn_parser *parser, const char *js, size_t len,
 				if (token == NULL)
 					return JSMN_ERROR_NOMEM;
 				if (parser->toksuper != -1) {
-					tokens[parser->toksuper].size++;
+					jsmntok_t *t = &tokens[parser->toksuper];
+#ifdef JSMN_STRICT
+					/* In strict mode an object or array can't become a key */
+					if (t->type == JSMN_OBJECT) {
+							return JSMN_ERROR_INVAL;
+					}
+#endif
+					t->size++;
 #ifdef JSMN_PARENT_LINKS
 					token->parent = parser->toksuper;
 #endif

--- a/test/tests.c
+++ b/test/tests.c
@@ -380,8 +380,30 @@ int test_unmatched_brackets(void) {
 				JSMN_OBJECT, 0, 16, 1,
 				JSMN_STRING, "key {1", 1,
 				JSMN_PRIMITIVE, "1234"));
-	js = "{{\"key 1\": 1234}";
-	check(parse(js, JSMN_ERROR_PART, 4));
+	js = "{\"key 1\":{\"key 2\": 1234}";
+	check(parse(js, JSMN_ERROR_PART, 5));
+	return 0;
+}
+
+int test_object_key(void) {
+	const char *js;
+
+	js = "{\"key\": 1}";
+	check(parse(js, 3, 3,
+				JSMN_OBJECT, 0, 10, 1,
+				JSMN_STRING, "key", 1,
+				JSMN_PRIMITIVE, "1"));
+#ifdef JSMN_STRICT
+	js = "{true: 1}";
+	check(parse(js, JSMN_ERROR_INVAL, 3));
+	js = "{1: 1}";
+	check(parse(js, JSMN_ERROR_INVAL, 3));
+	js = "{{\"key\": 1}: 2}";
+	check(parse(js, JSMN_ERROR_INVAL, 5));
+	js = "{[1,2]: 2}";
+	check(parse(js, JSMN_ERROR_INVAL, 5));
+#endif
+
 	return 0;
 }
 
@@ -402,6 +424,7 @@ int main(void) {
 	test(test_count, "test tokens count estimation");
 	test(test_nonstrict, "test for non-strict mode");
 	test(test_unmatched_brackets, "test for unmatched brackets");
+	test(test_object_key, "test for key type");
 	printf("\nPASSED: %d\nFAILED: %d\n", test_passed, test_failed);
 	return (test_failed > 0);
 }


### PR DESCRIPTION
In section "4 Object" of RFC 7159, a name of a object member is a string.  Even in current implementation, using a primitive is disallowed already in JSMN_STRICT.  I'd suggest disallowing an object or an array as well.