### PR TITLE
Quieten a warning from the compiler

### DIFF
--- a/jsmn.h
+++ b/jsmn.h
@@ -154,6 +154,9 @@ static int jsmn_parse_primitive(jsmn_parser *parser, const char *js,
     case ']':
     case '}':
       goto found;
+    default:
+                   /* to quiet a warning from gcc*/
+      break;
     }
     if (js[parser->pos] < 32 || js[parser->pos] >= 127) {
       parser->pos = start;


### PR DESCRIPTION
gcc (and others) like a default case for switch statement,
even if it is empty.

/close #161 