### PR TITLE
handles unterminated strings

### DIFF
--- a/jsmn.h
+++ b/jsmn.h
@@ -203,8 +203,13 @@ static int jsmn_parse_string(jsmn_parser *parser, const char *js,
   for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
     char c = js[parser->pos];
 
-    /* Quote: end of string */
+#ifdef JSMN_STRICT
+    /* In strict mode string must end with quotation mark */
     if (c == '\"') {
+#else
+    /* Quote or unescaped newline: end of string */
+    if (c == '\"' || c == '\n') {
+#endif
       if (tokens == NULL) {
         return 0;
       }


### PR DESCRIPTION
This change helps cases where a string starts with a quotation but without a quotation at its end in non-strict mode. 

With this change, a string will end upon encountering unescaped quotation mark or unescaped line feed. 

<br>

Without this change, the JSMN behaves inconsistently for such cases in non-strict mode, as explained below.

* If the unterminated string is not the last of an object or array, JSMN will continue to treat everything as part of the string even include unescaped line feed (until it sees the leading quotation mark of the next either array element or object key).

* If the unterminated string is the last of an object or array, JSMN returns error -3 JSMN_ERROR_PART immediately 

<br>

I used the following json snippets to test before and after this change.

```
{
    "first": "good",
    "middle": "bad
    "last": "good"
}
```

```
{
    "first": "good",
    "middle": "good",
    "last": "bad
}
```

(please go easy on me; this is my first PR) 