### PR TITLE
jsmn: declare struct names to allow forward decls

### DIFF
--- a/jsmn.h
+++ b/jsmn.h
@@ -66,7 +66,7 @@ enum jsmnerr {
  * start	start position in JSON data string
  * end		end position in JSON data string
  */
-typedef struct {
+typedef struct jsmntok {
   jsmntype_t type;
   int start;
   int end;
@@ -80,7 +80,7 @@ typedef struct {
  * JSON parser. Contains an array of token blocks available. Also stores
  * the string being parsed now and current position in that string.
  */
-typedef struct {
+typedef struct jsmn_parser {
   unsigned int pos;     /* offset in the JSON string */
   unsigned int toknext; /* next token to allocate */
   int toksuper;         /* superior token node, e.g. parent object or array */


### PR DESCRIPTION
Both `jsmntok_t` and `jsmn_parser` are declared as anonymous structures
that are typedeffed to their actual name. This forces all downstream
users of jsmn to always use the typedef name, instead of using e.g.
`struct jsmn_parser`. While this might be considered a matter of taste,
using typedefs only has the technical downside of disallowing forward
declarations. E.g. if a dependent whishes to declare a pointer to
`jsmntok_t` without actually pulling in the "jsmn.h" header, then he is
not able to do so because there is no way in C to provide a forward
declaration for typedefs to anonymous structs.

Fix this by providing names for both `jsmntok_t` and `jsmn_parser`
structures.