### PR TITLE
Fix variable scope warnings

### DIFF
--- a/jsmn.h
+++ b/jsmn.h
@@ -446,7 +446,7 @@ JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
   }
 
   if (tokens != NULL) {
-    for (i = parser->toknext - 1; i >= 0; i--) {
+    for (int i = parser->toknext - 1; i >= 0; i--) {
       /* Unmatched opened object or array */
       if (tokens[i].start != -1 && tokens[i].end == -1) {
         return JSMN_ERROR_PART;

--- a/jsmn.h
+++ b/jsmn.h
@@ -21,6 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+ /* Fixed variable scope warning by Ercan Ersoy. */
+
 #ifndef JSMN_H
 #define JSMN_H
 
@@ -268,7 +271,9 @@ static int jsmn_parse_string(jsmn_parser *parser, const char *js,
 JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
                         jsmntok_t *tokens, const unsigned int num_tokens) {
   int r;
+#ifndef JSMN_PARENT_LINKS
   int i;
+#endif
   jsmntok_t *token;
   int count = parser->toknext;
 

--- a/jsmn.h
+++ b/jsmn.h
@@ -446,7 +446,10 @@ JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
   }
 
   if (tokens != NULL) {
-    for (int i = parser->toknext - 1; i >= 0; i--) {
+#ifdef JSMN_PARENT_LINKS
+    int i;
+#endif
+    for (i = parser->toknext - 1; i >= 0; i--) {
       /* Unmatched opened object or array */
       if (tokens[i].start != -1 && tokens[i].end == -1) {
         return JSMN_ERROR_PART;

--- a/test/tests.c
+++ b/test/tests.c
@@ -1,3 +1,5 @@
+ /* Fixed variable scope warnings by Ercan Ersoy. */
+
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -97,7 +99,6 @@ int test_string(void) {
 }
 
 int test_partial_string(void) {
-  int r;
   unsigned long i;
   jsmn_parser p;
   jsmntok_t tok[5];
@@ -105,7 +106,7 @@ int test_partial_string(void) {
 
   jsmn_init(&p);
   for (i = 1; i <= strlen(js); i++) {
-    r = jsmn_parse(&p, js, i, tok, sizeof(tok) / sizeof(tok[0]));
+    int r = jsmn_parse(&p, js, i, tok, sizeof(tok) / sizeof(tok[0]));
     if (i == strlen(js)) {
       check(r == 5);
       check(tokeq(js, tok, 5, JSMN_OBJECT, -1, -1, 2, JSMN_STRING, "x", 1,
@@ -120,7 +121,6 @@ int test_partial_string(void) {
 
 int test_partial_array(void) {
 #ifdef JSMN_STRICT
-  int r;
   unsigned long i;
   jsmn_parser p;
   jsmntok_t tok[10];
@@ -128,7 +128,7 @@ int test_partial_array(void) {
 
   jsmn_init(&p);
   for (i = 1; i <= strlen(js); i++) {
-    r = jsmn_parse(&p, js, i, tok, sizeof(tok) / sizeof(tok[0]));
+    int r = jsmn_parse(&p, js, i, tok, sizeof(tok) / sizeof(tok[0]));
     if (i == strlen(js)) {
       check(r == 6);
       check(tokeq(js, tok, 6, JSMN_ARRAY, -1, -1, 3, JSMN_PRIMITIVE, "1",
@@ -144,7 +144,6 @@ int test_partial_array(void) {
 
 int test_array_nomem(void) {
   int i;
-  int r;
   jsmn_parser p;
   jsmntok_t toksmall[10], toklarge[10];
   const char *js;
@@ -155,7 +154,7 @@ int test_array_nomem(void) {
     jsmn_init(&p);
     memset(toksmall, 0, sizeof(toksmall));
     memset(toklarge, 0, sizeof(toklarge));
-    r = jsmn_parse(&p, js, strlen(js), toksmall, i);
+    int r = jsmn_parse(&p, js, strlen(js), toksmall, i);
     check(r == JSMN_ERROR_NOMEM);
 
     memcpy(toklarge, toksmall, sizeof(toksmall));

--- a/test/testutil.h
+++ b/test/testutil.h
@@ -1,3 +1,5 @@
+ /* Fixed variable scope warning by Ercan Ersoy. */
+
 #ifndef __TEST_UTIL_H__
 #define __TEST_UTIL_H__
 
@@ -73,7 +75,6 @@ static int tokeq(const char *s, jsmntok_t *tokens, unsigned long numtok, ...) {
 static int parse(const char *s, int status, unsigned long numtok, ...) {
   int r;
   int ok = 1;
-  va_list args;
   jsmn_parser p;
   jsmntok_t *t = malloc(numtok * sizeof(jsmntok_t));
 
@@ -85,6 +86,7 @@ static int parse(const char *s, int status, unsigned long numtok, ...) {
   }
 
   if (status >= 0) {
+    va_list args;
     va_start(args, numtok);
     ok = vtokeq(s, t, numtok, args);
     va_end(args);


### PR DESCRIPTION
Fixed variable scope warnings on jsmn.h, test/testc.c and test/testutil.h files.

These warnings have been founded by using Cppcheck 1.86.