### PR TITLE
Comply with RFC 8259 in strict mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ clean:
 	rm -f *.o example/*.o
 	rm -f simple_example
 	rm -f jsondump
+	rm -f test/test_default test/test_strict test/test_links test/test_strict_links
 
 .PHONY: clean test
 

--- a/jsmn.h
+++ b/jsmn.h
@@ -99,7 +99,7 @@ typedef enum {
   JSMN_STATE_OBJ_NEW = (JSMN_KEY | JSMN_CAN_CLOSE),
   /* Just saw a comma in an object. Expecting key. */
   JSMN_STATE_OBJ_KEY = (JSMN_KEY),
-  /* Just saw a key in an object. Expecting colon or maybe close/comma. */
+  /* Just saw a key in an object. Expecting colon. */
   JSMN_STATE_OBJ_COLON = (JSMN_KEY | JSMN_DELIMITER),
   /* Just saw a colon in an object. Expecting value. */
   JSMN_STATE_OBJ_VAL = (JSMN_VALUE),

--- a/jsmn.h
+++ b/jsmn.h
@@ -142,7 +142,7 @@ static jsmntok_t *jsmn_alloc_token(jsmn_parser *parser, jsmntok_t *tokens,
   tok->end = 0;
   tok->size = 0;
 #ifdef JSMN_PARENT_LINKS
-  tok->parent = -1;
+  tok->parent = parser->tokbefore;
 #endif
   return tok;
 }
@@ -429,7 +429,7 @@ static int jsmn_parse_string(jsmn_parser *parser, const char *js,
     if (c == '\\' && parser->pos + 1 < len) {
       int i;
       parser->pos++;
-#ifndef JSMN_STRICT
+#ifdef JSMN_STRICT
       switch (js[parser->pos]) {
       /* Allowed escaped symbols */
       case '\"':

--- a/jsmn.h
+++ b/jsmn.h
@@ -208,7 +208,7 @@ static int jsmn_parse_primitive(jsmn_parser *parser, const char *js,
 #ifdef JSMN_STRICT
   if (js[parser->pos] == 't') {
     for (i = 1;
-         i < strlen(true_str);
+         i < sizeof(true_str) - 1;
          i++) {
       if (parser->pos + i >= len || js[parser->pos + i] == '\0') {
         return JSMN_ERROR_PART;
@@ -219,7 +219,7 @@ static int jsmn_parse_primitive(jsmn_parser *parser, const char *js,
     parser->pos += 4;
   } else if (js[parser->pos] == 'f') {
     for (i = 1;
-         i < strlen(false_str);
+         i < sizeof(false_str) - 1;
          i++) {
       if (parser->pos + i >= len || js[parser->pos + i] == '\0') {
         return JSMN_ERROR_PART;
@@ -230,7 +230,7 @@ static int jsmn_parse_primitive(jsmn_parser *parser, const char *js,
     parser->pos += 5;
   } else if (js[parser->pos] == 'n') {
     for (i = 1;
-         i < strlen(null_str);
+         i < sizeof(null_str) - 1;
          i++) {
       if (parser->pos + i >= len || js[parser->pos + i] == '\0') {
         return JSMN_ERROR_PART;

--- a/jsmn.h
+++ b/jsmn.h
@@ -407,15 +407,20 @@ container_close:
         return r;
       }
       count++;
+      if (tokens == NULL) {
+        if (depth == 0) {
+          return count;
+        } else {
+          break;
+        }
+      }
       if (parser->toksuper == -1) {
         return count;
-      } else if (tokens != NULL) {
-        if (parser->state & 0x1) {
-          return JSMN_ERROR_INVAL;
-        }
-        parser->state++;
-        tokens[parser->toksuper].size++;
+      } else if (parser->state & 0x1) {
+        return JSMN_ERROR_INVAL;
       }
+      parser->state++;
+      tokens[parser->toksuper].size++;
       break;
     case '\t':
     case '\r':
@@ -475,19 +480,24 @@ container_close:
         return r;
       }
       count++;
+      if (tokens == NULL) {
+        if (depth == 0) {
+          return count;
+        } else {
+          break;
+        }
+      }
       if (parser->toksuper == -1) {
         return count;
-      } else if (tokens != NULL) {
 #ifdef JSMN_STRICT
-        if (parser->state & 0x3) {
+      } else if (parser->state & 0x3) {
 #else
-        if (parser->state & 0x1) {
+      } else if (parser->state & 0x1) {
 #endif
-          return JSMN_ERROR_INVAL;
-        }
-        parser->state++;
-        tokens[parser->toksuper].size++;
+        return JSMN_ERROR_INVAL;
       }
+      parser->state++;
+      tokens[parser->toksuper].size++;
       break;
 #ifdef JSMN_STRICT
     /* Unexpected char in strict mode */

--- a/jsmn.h
+++ b/jsmn.h
@@ -99,7 +99,7 @@ typedef enum {
   JSMN_STATE_OBJ_COMMA = 0x15,    /* Expecting object comma or } */
   JSMN_STATE_ARRAY_NEW = 0x24,    /* Expecting array item or ] */
   JSMN_STATE_ARRAY_ITEM = 0x20,   /* Expecting array item */
-  JSMN_STATE_ARRAY_COMMA = 0x25,  /* Expecting array comma or ] */
+  JSMN_STATE_ARRAY_COMMA = 0x25   /* Expecting array comma or ] */
 } jsmnstate_t;
 
 /**
@@ -158,9 +158,9 @@ static void jsmn_fill_token(jsmntok_t *token, const jsmntype_t type,
 }
 
 #ifdef JSMN_STRICT
-static char true_str[] = "true";
-static char false_str[] = "false";
-static char null_str[] = "null";
+static const char true_str[] = "true";
+static const char false_str[] = "false";
+static const char null_str[] = "null";
 
 typedef enum {
   JSMN_NUM_INT_START,

--- a/jsmn.h
+++ b/jsmn.h
@@ -98,7 +98,7 @@ typedef enum {
   JSMN_STATE_OBJ_KEY = 0x12,      /* Expecting object key */
   JSMN_STATE_OBJ_COLON = 0x13,    /* Expecting object colon */
   JSMN_STATE_OBJ_VAL = 0x10,      /* Expecting object value */
-  JSMN_STATE_OBJ_COMMA = 0x11     /* Expecting object comma or } */
+  JSMN_STATE_OBJ_COMMA = 0x11,    /* Expecting object comma or } */
   JSMN_STATE_ARRAY_ITEM = 0x20,   /* Expecting array item */
   JSMN_STATE_ARRAY_COMMA = 0x21,  /* Expecting array comma or ] */
 } jsmnstate_t;
@@ -369,7 +369,7 @@ JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
           return count;
         }
         break;
-      } else if (jsmn->state != JSMN_STATE_OBJ_COMMA) {
+      } else if (parser->state != JSMN_STATE_OBJ_COMMA) {
         return JSMN_ERROR_INVAL;
       }
       goto container_close;
@@ -380,7 +380,7 @@ JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
           return count;
         }
         break;
-      } else if (jsmn->state != JSMN_STATE_ARRAY_COMMA) {
+      } else if (parser->state != JSMN_STATE_ARRAY_COMMA) {
         return JSMN_ERROR_INVAL;
       }
 container_close:
@@ -399,7 +399,7 @@ container_close:
       if (parser->toksuper == -1) {
         return count;
       } else {
-        jsmn->state = tokens[parser->toksuper].type << 4 & 0x1;
+        parser->state = tokens[parser->toksuper].type << 4 & 0x1;
       }
     case '\"':
       r = jsmn_parse_string(parser, js, len, tokens, num_tokens);
@@ -408,7 +408,7 @@ container_close:
       }
       count++;
       if (tokens == NULL) {
-        if (depth == 0) {
+        if (parser->depth == 0) {
           return count;
         } else {
           break;
@@ -481,7 +481,7 @@ container_close:
       }
       count++;
       if (tokens == NULL) {
-        if (depth == 0) {
+        if (parser->depth == 0) {
           return count;
         } else {
           break;

--- a/jsmn.h
+++ b/jsmn.h
@@ -429,6 +429,7 @@ static int jsmn_parse_string(jsmn_parser *parser, const char *js,
     if (c == '\\' && parser->pos + 1 < len) {
       int i;
       parser->pos++;
+#ifndef JSMN_STRICT
       switch (js[parser->pos]) {
       /* Allowed escaped symbols */
       case '\"':
@@ -461,7 +462,16 @@ static int jsmn_parse_string(jsmn_parser *parser, const char *js,
         parser->pos = start;
         return JSMN_ERROR_INVAL;
       }
+#endif
     }
+
+#ifdef JSMN_STRICT
+    /* No control characters allowed in strict mode */
+    if (c >= 0 && c < 32) {
+      parser->pos = start;
+      return JSMN_ERROR_INVAL;
+    }
+#endif
   }
   parser->pos = start;
   return JSMN_ERROR_PART;

--- a/test/tests.c
+++ b/test/tests.c
@@ -125,7 +125,6 @@ int test_partial_string(void) {
 }
 
 int test_partial_array(void) {
-#ifdef JSMN_STRICT
   int r;
   unsigned long i;
   jsmn_parser p;
@@ -144,7 +143,6 @@ int test_partial_array(void) {
       check(r == JSMN_ERROR_PART);
     }
   }
-#endif
   return 0;
 }
 

--- a/test/tests.c
+++ b/test/tests.c
@@ -33,28 +33,34 @@ int test_object(void) {
 #ifdef JSMN_STRICT
   check(parse("{\"a\"\n0}", JSMN_ERROR_INVAL, 3));
   check(parse("{\"a\", 0}", JSMN_ERROR_INVAL, 3));
-  check(parse("{\"a\": {2}}", JSMN_ERROR_INVAL, 3));
-  check(parse("{\"a\": {2: 3}}", JSMN_ERROR_INVAL, 3));
-  check(parse("{\"a\": {\"a\": 2 3}}", JSMN_ERROR_INVAL, 5));
-/* FIXME */
-/*check(parse("{\"a\"}", JSMN_ERROR_INVAL, 2));*/
-/*check(parse("{\"a\": 1, \"b\"}", JSMN_ERROR_INVAL, 4));*/
-/*check(parse("{\"a\",\"b\":1}", JSMN_ERROR_INVAL, 4));*/
-/*check(parse("{\"a\":1,}", JSMN_ERROR_INVAL, 4));*/
-/*check(parse("{\"a\":\"b\":\"c\"}", JSMN_ERROR_INVAL, 4));*/
-/*check(parse("{,}", JSMN_ERROR_INVAL, 4));*/
+  check(parse("{\"a\": {2}}", JSMN_ERROR_INVAL, 4));
+  check(parse("{\"a\": {2: 3}}", JSMN_ERROR_INVAL, 5));
+  check(parse("{\"a\": {\"a\": 2 3}}", JSMN_ERROR_INVAL, 6));
+  check(parse("{\"a\"}", JSMN_ERROR_INVAL, 2));
+  check(parse("{\"a\": 1, \"b\"}", JSMN_ERROR_INVAL, 4));
+  check(parse("{\"a\",\"b\":1}", JSMN_ERROR_INVAL, 4));
+  check(parse("{\"a\":1,}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"a\":\"b\":\"c\"}", JSMN_ERROR_INVAL, 4));
+  check(parse("{,}", JSMN_ERROR_INVAL, 1));
+  check(parse("{\"a\":}", JSMN_ERROR_INVAL, 2));
+  check(parse("{\"a\" \"b\"}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"a\" ::::: \"b\"}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"a\": [1 \"b\"]}", JSMN_ERROR_INVAL, 5));
+  check(parse("{\"a\"\"\"}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"a\":1\"\"}", JSMN_ERROR_INVAL, 4));
+  check(parse("{\"a\":1\"b\":1}", JSMN_ERROR_INVAL, 5));
+  check(parse("{\"a\":\"b\", \"c\":\"d\", {\"e\": \"f\"}}",
+              JSMN_ERROR_INVAL, 8));
 #endif
   return 0;
 }
 
 int test_array(void) {
-  /* FIXME */
-  /*check(parse("[10}", JSMN_ERROR_INVAL, 3));*/
-  /*check(parse("[1,,3]", JSMN_ERROR_INVAL, 3)*/
+  check(parse("[10}", JSMN_ERROR_INVAL, 3));
+  check(parse("[1,,3]", JSMN_ERROR_INVAL, 3));
   check(parse("[10]", 2, 2, JSMN_ARRAY, -1, -1, 1, JSMN_PRIMITIVE, "10"));
   check(parse("{\"a\": 1]", JSMN_ERROR_INVAL, 3));
-  /* FIXME */
-  /*check(parse("[\"a\": 1]", JSMN_ERROR_INVAL, 3));*/
+  check(parse("[\"a\": 1]", JSMN_ERROR_INVAL, 3));
   return 0;
 }
 
@@ -177,12 +183,13 @@ int test_unquoted_keys(void) {
   const char *js;
 
   jsmn_init(&p);
-  js = "key1: \"value\"\nkey2 : 123";
+  js = "{key1: \"value\", key2 : 123}";
 
   r = jsmn_parse(&p, js, strlen(js), tok, 10);
   check(r >= 0);
-  check(tokeq(js, tok, 4, JSMN_PRIMITIVE, "key1", JSMN_STRING, "value", 0,
-              JSMN_PRIMITIVE, "key2", JSMN_PRIMITIVE, "123"));
+  check(tokeq(js, tok, 5, JSMN_OBJECT, -1, -1, 2, JSMN_PRIMITIVE, "key1",
+              JSMN_STRING, "value", 0, JSMN_PRIMITIVE, "key2",
+              JSMN_PRIMITIVE, "123"));
 #endif
   return 0;
 }
@@ -301,14 +308,15 @@ int test_nonstrict(void) {
 
 int test_unmatched_brackets(void) {
   const char *js;
-  js = "\"key 1\": 1234}";
-  check(parse(js, JSMN_ERROR_INVAL, 2));
+  /* js = "\"key 1\": 1234}";
+  check(parse(js, JSMN_ERROR_INVAL, 2)); */
   js = "{\"key 1\": 1234";
   check(parse(js, JSMN_ERROR_PART, 3));
+  /*
   js = "{\"key 1\": 1234}}";
   check(parse(js, JSMN_ERROR_INVAL, 3));
   js = "\"key 1\"}: 1234";
-  check(parse(js, JSMN_ERROR_INVAL, 3));
+  check(parse(js, JSMN_ERROR_INVAL, 3));*/
   js = "{\"key {1\": 1234}";
   check(parse(js, 3, 3, JSMN_OBJECT, 0, 16, 1, JSMN_STRING, "key {1", 1,
               JSMN_PRIMITIVE, "1234"));
@@ -349,9 +357,9 @@ int main(void) {
   test(test_unquoted_keys, "test unquoted keys (like in JavaScript)");
   test(test_input_length, "test strings that are not null-terminated");
   test(test_issue_22, "test issue #22");
-  test(test_issue_27, "test issue #27");
+  /* test(test_issue_27, "test issue #27"); */
   test(test_count, "test tokens count estimation");
-  test(test_nonstrict, "test for non-strict mode");
+  /* test(test_nonstrict, "test for non-strict mode"); */
   test(test_unmatched_brackets, "test for unmatched brackets");
   test(test_object_key, "test for key type");
   printf("\nPASSED: %d\nFAILED: %d\n", test_passed, test_failed);

--- a/test/tests.c
+++ b/test/tests.c
@@ -387,7 +387,7 @@ int test_unenclosed(void) {
   check(parse(js, 1, 1, JSMN_PRIMITIVE, "fal"));
  
   js = "fal ";
-  check(parse(js, 1, 1, JSMN_PRIMITIVE, "fal "));
+  check(parse(js, 1, 1, JSMN_PRIMITIVE, "fal"));
 #endif
  
   js = "\"a\": 0";
@@ -493,7 +493,7 @@ int main(void) {
   test(test_input_length, "test strings that are not null-terminated");
   test(test_issue_22, "test issue #22");
   test(test_count, "test tokens count estimation");
-  /* test(test_unenclosed, "test for non-strict mode"); */
+   test(test_unenclosed, "test for non-strict mode");
   test(test_unmatched_brackets, "test for unmatched brackets");
   test(test_object_key, "test for key type");
   test(test_multiple_objects, "test parsing multiple items at once");

--- a/test/tests.c
+++ b/test/tests.c
@@ -306,15 +306,15 @@ int test_nonstrict(void) {
 
 int test_unmatched_brackets(void) {
   const char *js;
-  /* js = "\"key 1\": 1234}";
-  check(parse(js, JSMN_ERROR_INVAL, 2)); */
+  js = "\"key 1\": 1234}";
+  check(parse(js, JSMN_ERROR_INVAL, 2));
   js = "{\"key 1\": 1234";
   check(parse(js, JSMN_ERROR_PART, 3));
-  /*
+  
   js = "{\"key 1\": 1234}}";
   check(parse(js, JSMN_ERROR_INVAL, 3));
   js = "\"key 1\"}: 1234";
-  check(parse(js, JSMN_ERROR_INVAL, 3));*/
+  check(parse(js, JSMN_ERROR_INVAL, 3));
   js = "{\"key {1\": 1234}";
   check(parse(js, 3, 3, JSMN_OBJECT, 0, 16, 1, JSMN_STRING, "key {1", 1,
               JSMN_PRIMITIVE, "1234"));
@@ -355,7 +355,7 @@ int main(void) {
   test(test_unquoted_keys, "test unquoted keys (like in JavaScript)");
   test(test_input_length, "test strings that are not null-terminated");
   test(test_issue_22, "test issue #22");
-  /* test(test_issue_27, "test issue #27"); */
+  test(test_issue_27, "test issue #27");
   test(test_count, "test tokens count estimation");
   /* test(test_nonstrict, "test for non-strict mode"); */
   test(test_unmatched_brackets, "test for unmatched brackets");

--- a/test/tests.c
+++ b/test/tests.c
@@ -73,8 +73,54 @@ int test_primitive(void) {
               JSMN_STRING, "nullVar", 1, JSMN_PRIMITIVE, "null"));
   check(parse("{\"intVar\" : 12}", 3, 3, JSMN_OBJECT, -1, -1, 1, JSMN_STRING,
               "intVar", 1, JSMN_PRIMITIVE, "12"));
+  check(parse("{\"intVar\" : 0}", 3, 3, JSMN_OBJECT, -1, -1, 1, JSMN_STRING,
+              "intVar", 1, JSMN_PRIMITIVE, "0"));
   check(parse("{\"floatVar\" : 12.345}", 3, 3, JSMN_OBJECT, -1, -1, 1,
               JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "12.345"));
+  check(parse("{\"floatVar\" : -12.345}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "-12.345"));
+  check(parse("{\"floatVar\" : 0.345}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "0.345"));
+  check(parse("{\"floatVar\" : 12.345e6}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "12.345e6"));
+  check(parse("{\"floatVar\" : 12.345E+6}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "12.345E+6"));
+  check(parse("{\"floatVar\" : 12e+6}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "12e+6"));
+
+#ifdef JSMN_STRICT
+  check(parse("{\"boolVar\" : tru }", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"boolVar\" : falsee }", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"nullVar\" : nulm }", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"intVar\" : 01}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"floatVar\" : .345}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"floatVar\" : -}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"floatVar\" : 12.}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"floatVar\" : 12.}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"floatVar\" : +12}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"floatVar\" : 12.345e-}", JSMN_ERROR_INVAL, 3));
+#else
+  check(parse("{\"boolVar\" : tru }", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "boolVar", 1, JSMN_PRIMITIVE, "tru"));
+  check(parse("{\"boolVar\" : falsee }", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "boolVar", 1, JSMN_PRIMITIVE, "falsee"));
+  check(parse("{\"nullVar\" : nulm }", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "nullVar", 1, JSMN_PRIMITIVE, "nulm"));
+  check(parse("{\"intVar\" : 01}", 3, 3, JSMN_OBJECT, -1, -1, 1, JSMN_STRING,
+              "intVar", 1, JSMN_PRIMITIVE, "01"));
+  check(parse("{\"floatVar\" : .345}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, ".345"));
+  check(parse("{\"floatVar\" : -}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "-"));
+  check(parse("{\"floatVar\" : 12.}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "12."));
+  check(parse("{\"floatVar\" : 12.}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "12."));
+  check(parse("{\"floatVar\" : +12}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "+12"));
+  check(parse("{\"floatVar\" : 12.345e-}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "12.345e-"));
+#endif
   return 0;
 }
 
@@ -95,10 +141,26 @@ int test_string(void) {
   check(parse("{\"a\":[\"\\u0280\"]}", 4, 4, JSMN_OBJECT, -1, -1, 1,
               JSMN_STRING, "a", 1, JSMN_ARRAY, -1, -1, 1, JSMN_STRING,
               "\\u0280", 0));
+  /* \xc2\xa9 is the copyright symbol in UTF-8 */
+  check(parse("{\"a\":\"str\xc2\xa9\"}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "a", 1, JSMN_STRING, "str\xc2\xa9", 0));
 
+#ifdef JSMN_STRICT
+  check(parse("{\"a\":\"str\nstr\"}", JSMN_ERROR_INVAL, 3));
   check(parse("{\"a\":\"str\\uFFGFstr\"}", JSMN_ERROR_INVAL, 3));
   check(parse("{\"a\":\"str\\u@FfF\"}", JSMN_ERROR_INVAL, 3));
-  check(parse("{{\"a\":[\"\\u028\"]}", JSMN_ERROR_INVAL, 4));
+  check(parse("{\"a\":[\"\\u028\"]}", JSMN_ERROR_INVAL, 4));
+#else
+  check(parse("{\"a\":\"str\nstr\"}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "a", 1, JSMN_STRING, "str\nstr", 0));
+  check(parse("{\"a\":\"str\\uFFGFstr\"}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "a", 1, JSMN_STRING, "str\\uFFGFstr", 0));
+  check(parse("{\"a\":\"str\\u@FfF\"}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "a", 1, JSMN_STRING, "str\\u@FfF", 0));
+  check(parse("{\"a\":[\"\\u028\"]}", 4, 4, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "a", 1, JSMN_ARRAY, -1, -1, 1,
+              JSMN_STRING, "\\u028", 0));
+#endif
   return 0;
 }
 
@@ -215,13 +277,6 @@ int test_issue_22(void) {
   return 0;
 }
 
-int test_issue_27(void) {
-  const char *js =
-      "{ \"name\" : \"Jack\", \"age\" : 27 } { \"name\" : \"Anna\", ";
-  check(parse(js, JSMN_ERROR_PART, 8));
-  return 0;
-}
-
 int test_input_length(void) {
   const char *js;
   int r;
@@ -285,9 +340,64 @@ int test_count(void) {
   return 0;
 }
 
-int test_nonstrict(void) {
-#ifndef JSMN_STRICT
+int test_unenclosed(void) {
   const char *js;
+  js = "1234";
+  check(parse(js, 1, 1, JSMN_PRIMITIVE, "1234"));
+
+  js = "false";
+  check(parse(js, 1, 1, JSMN_PRIMITIVE, "false"));
+ 
+  js = "0garbage";
+#ifdef JSMN_STRICT
+  check(parse(js, JSMN_ERROR_INVAL, 1));
+#else
+  check(parse(js, 1, 1, JSMN_PRIMITIVE, "0garbage"));
+#endif
+
+  js = "\"0garbage\"";
+  check(parse(js, 1, 1, JSMN_STRING, "0garbage", 0));
+
+  js = "\"0garbage";
+  check(parse(js, JSMN_ERROR_PART, 1));
+
+  js = "1234\"0garbage\"";
+  check(parse(js, 2, 2, JSMN_PRIMITIVE, "1234", JSMN_STRING, "0garbage", 0));
+
+  js = "\"0garbage\"1234";
+  check(parse(js, 2, 2, JSMN_STRING, "0garbage", 0, JSMN_PRIMITIVE, "1234"));
+
+  js = " 1234";
+  check(parse(js, 1, 1, JSMN_PRIMITIVE, "1234"));
+
+  js = "1234 ";
+  check(parse(js, 1, 1, JSMN_PRIMITIVE, "1234"));
+
+  js = " 1234 ";
+  check(parse(js, 1, 1, JSMN_PRIMITIVE, "1234"));
+
+#ifdef JSMN_STRICT
+  js = "fal";
+  check(parse(js, JSMN_ERROR_PART, 1));
+ 
+  js = "fal ";
+  check(parse(js, JSMN_ERROR_INVAL, 1));
+#else
+  js = "fal";
+  check(parse(js, 1, 1, JSMN_PRIMITIVE, "fal"));
+ 
+  js = "fal ";
+  check(parse(js, 1, 1, JSMN_PRIMITIVE, "fal "));
+#endif
+ 
+  js = "\"a\": 0";
+  check(parse(js, JSMN_ERROR_INVAL, 2));
+
+  js = "\"a\", 0";
+  check(parse(js, JSMN_ERROR_INVAL, 2));
+
+  /* XXX No longer valid after RFC 8259 fixes
+#ifndef JSMN_STRICT
   js = "a: 0garbage";
   check(parse(js, 2, 2, JSMN_PRIMITIVE, "a", JSMN_PRIMITIVE, "0garbage"));
 
@@ -295,12 +405,14 @@ int test_nonstrict(void) {
   check(parse(js, 6, 6, JSMN_PRIMITIVE, "Day", JSMN_PRIMITIVE, "26",
               JSMN_PRIMITIVE, "Month", JSMN_PRIMITIVE, "Sep", JSMN_PRIMITIVE,
               "Year", JSMN_PRIMITIVE, "12"));
+  */
 
   /* nested {s don't cause a parse error. */
+  /* XXX No longer valid after RFC 8259 fixes
   js = "\"key {1\": 1234";
   check(parse(js, 2, 2, JSMN_STRING, "key {1", 1, JSMN_PRIMITIVE, "1234"));
-
 #endif
+  */
   return 0;
 }
 
@@ -342,6 +454,31 @@ int test_object_key(void) {
   return 0;
 }
 
+int test_multiple_objects(void) {
+  const char *js;
+  js = "true {\"def\": 123}";
+  check(parse(js, 4, 4, JSMN_PRIMITIVE, "true", JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "def", 1, JSMN_PRIMITIVE, "123"));
+
+  js = "{\"def\": 123} true";
+  check(parse(js, 4, 4, JSMN_OBJECT, -1, -1, 1, JSMN_STRING, "def", 1,
+              JSMN_PRIMITIVE, "123", JSMN_PRIMITIVE, "true"));
+
+  js = "true{\"def\": 123}";
+  check(parse(js, 4, 4, JSMN_PRIMITIVE, "true", JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "def", 1, JSMN_PRIMITIVE, "123"));
+
+  js = "[true, \"abc\"]{\"def\": 123}";
+  check(parse(js, 6, 6, JSMN_ARRAY, -1, -1, 2, JSMN_PRIMITIVE, "true",
+              JSMN_STRING, "abc", 0, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "def", 1, JSMN_PRIMITIVE, "123"));
+
+  /* Issue #27 */
+  js = "{ \"name\" : \"Jack\", \"age\" : 27 } { \"name\" : \"Anna\", ";
+  check(parse(js, JSMN_ERROR_PART, 8));
+  return 0;
+}
+
 int main(void) {
   test(test_empty, "test for a empty JSON objects/arrays");
   test(test_object, "test for a JSON objects");
@@ -355,11 +492,11 @@ int main(void) {
   test(test_unquoted_keys, "test unquoted keys (like in JavaScript)");
   test(test_input_length, "test strings that are not null-terminated");
   test(test_issue_22, "test issue #22");
-  test(test_issue_27, "test issue #27");
   test(test_count, "test tokens count estimation");
-  /* test(test_nonstrict, "test for non-strict mode"); */
+  /* test(test_unenclosed, "test for non-strict mode"); */
   test(test_unmatched_brackets, "test for unmatched brackets");
   test(test_object_key, "test for key type");
+  test(test_multiple_objects, "test parsing multiple items at once");
   printf("\nPASSED: %d\nFAILED: %d\n", test_passed, test_failed);
   return (test_failed > 0);
 }


### PR DESCRIPTION
### This PR brings strict mode in compliance with RFC 8259 (as well as some other changes):
- Various invalid inputs that were accepted before are now correctly rejected (Fixes #41, fixes #52, fixes #117, fixes #131, fixes #158)
- Primitives and strings are fully validated according to RFC 8259 (Fixes #178). (And in non-strict mode, both are now fully relaxed.)
- Strings and primitives are allowed at the root level, not just objects and arrays. (As part of this, fixed #179, which started affecting strict mode with this change)
  There is an important caveat with primitives at the root level related to #179: If a number (or any primitive in non-strict mode) is split across incremental parses at the root level, an incomplete token will likely be produced on the first pass instead of `JSMN_ERROR_PART`. The parser has no way of knowing the token is incomplete. It will be corrected on the second pass when the full input string is available.
- Arrays and objects disallowed as keys due to issues they cause (Fixes #193). This isn't related to strict mode at all, but while digging in to implement the above, it made sense to address this as well. More on why this change made sense later.
- Calling `jsmn_parse()` with `tokens` set to `NULL` skips a lot of the validation, even in strict mode. (The assumption being that this is almost always called right before a `jsmn_parse()` with `tokens` allocated, so for almost all use cases, this saves from doing the validations twice.)

At the same time, this led to some significant changes to non-strict mode (consistent with comments I previously made [on issue #154](https://github.com/zserge/jsmn/issues/154#issuecomment-632372461)). In summary, non-strict mode is now limited to the following three deviations from RFC 8259: 1) Primitives can be made of any character that doesn't have special meaning in JSON (whitespace and any of `{}[],:"`), 2) Strings can contain any character and invalid backslash escapes, and 3) Primitives can be object keys, not just strings. Reasoning for these changes is below. (But see also [comment later](https://github.com/zserge/jsmn/pull/194#issuecomment-637062774).)

#### Unenclosed objects, missing values, and missing commas

Non-strict mode previously allowed the following examples to parse:

```
"server": "127.0.0.1"
"port": 80
"message": "Hello world"
```

```
{"a":1 "b":2}
```

```
{
  "a":1,
  "b"
}
```

I believe this was intentional; however, this relaxed validation carried over into strict mode in several places (see issues #52, #131, #158). I added a simple state machine to the parser to fix the issues in strict mode, but fixing strict mode without affecting non-strict mode would have been difficult. As a result, non-strict mode no longer allows the above examples. I can think of ways we could make it work, but the added complexity didn't seem worth it.

#### Arrays and objects as keys

Non-strict mode no longer allows arrays and objects as object keys. This eliminates issue #193, but breaks backward compatibility for some non-RFC-8259-compliant JSON. Here is the reasoning:
- When we add a value to a key, we add one to the key's size and the key becomes the value's parent. This does a couple nice things:
  - Keys can be identified by checking for non-arrays and non-objects with `size` 1
  - The total number of tokens in any JSON object (or array) is the recursive sum of that object's `size` and its children's `size`s, plus one for the object itself (very convenient for skipping array items or members of an object)
- When arrays and objects are keys, not only are those promises broken, but implementation is non-trivial, since `size` is already used for their own contents. This is the cause of issue #193. I could think of three potential fixes:
  - Don't increment `size` for a key when it's an array or object. This fixes #193 but still breaks the promises above, and adds noticeable complexity to the code. I don't like this solution.
  - Differentiate between container-child relationship and key-value relationship. Add a way to identify keys without using `size`: either a new `key` field in `jsmntok_t` or modify `jsmntype_t`:
    ```
    typedef enum {
      JSMN_UNDEFINED = 0x0,
      JSMN_OBJECT = 0x1,
      JSMN_ARRAY = 0x2,
      JSMN_STRING = 0x4,
      JSMN_PRIMITIVE = 0x8,
      JSMN_OBJECT_KEY = 0x11,
      JSMN_ARRAY_KEY = 0x12,
      JSMN_STRING_KEY = 0x14,
      JSMN_PRIMITIVE_KEY = 0x18,
    } jsmntype_t;
    ```
    and then add a `keytok` field alongside `supertok` in `jmsn_parser`. This could be enabled only when `JSMN_STRICT` is not defined. I don't hate this idea, but it *is* extra work for what is ultimately non-RFC-8259-compliant JSON. It still doesn't seem with the effort.
  - Don't allow objects and arrays to be keys, sidestepping the issue entirely. This minimizes the amount of extra code for non-strict mode. This is the solution I chose. If really missed, we could add array/object keys back as a separate change.

#### Conclusion

These are some pretty significant changes to jsmn, but seeing the number of issues about invalid input being accepted, I hope they are well received. I have some ideas for future improvements also, but I will discuss that on the Roadmap issue (#159).