### PR TITLE
Enhancements for feature macros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,27 @@
 # You can put your build options here
 -include config.mk
 
-test: test_default test_strict test_links test_strict_links
+test: test_default test_nonstrict test_lowmem test_nonstrict_lowmem test_permissiveprims test_permissivestrs test_primkeys
 test_default: test/tests.c jsmn.h
 	$(CC) $(CFLAGS) $(LDFLAGS) $< -o test/$@
 	./test/$@
-test_strict: test/tests.c jsmn.h
-	$(CC) -DJSMN_STRICT=1 $(CFLAGS) $(LDFLAGS) $< -o test/$@
+test_nonstrict: test/tests.c jsmn.h
+	$(CC) -DJSMN_NON_STRICT=1 $(CFLAGS) $(LDFLAGS) $< -o test/$@
 	./test/$@
-test_links: test/tests.c jsmn.h
-	$(CC) -DJSMN_PARENT_LINKS=1 $(CFLAGS) $(LDFLAGS) $< -o test/$@
+test_lowmem: test/tests.c jsmn.h
+	$(CC) -DJSMN_LOW_MEMORY=1 $(CFLAGS) $(LDFLAGS) $< -o test/$@
 	./test/$@
-test_strict_links: test/tests.c jsmn.h
-	$(CC) -DJSMN_STRICT=1 -DJSMN_PARENT_LINKS=1 $(CFLAGS) $(LDFLAGS) $< -o test/$@
+test_nonstrict_lowmem: test/tests.c jsmn.h
+	$(CC) -DJSMN_NON_STRICT=1 -DJSMN_LOW_MEMORY=1 $(CFLAGS) $(LDFLAGS) $< -o test/$@
+	./test/$@
+test_permissiveprims: test/tests.c jsmn.h
+	$(CC) -DJSMN_PERMISSIVE_PRIMITIVES=1 $(CFLAGS) $(LDFLAGS) $< -o test/$@
+	./test/$@
+test_permissivestrs: test/tests.c jsmn.h
+	$(CC) -DJSMN_PERMISSIVE_STRINGS=1 $(CFLAGS) $(LDFLAGS) $< -o test/$@
+	./test/$@
+test_primkeys: test/tests.c jsmn.h
+	$(CC) -DJSMN_PRIMITIVE_KEYS=1 $(CFLAGS) $(LDFLAGS) $< -o test/$@
 	./test/$@
 
 simple_example: example/simple.c jsmn.h
@@ -31,7 +40,7 @@ clean:
 	rm -f *.o example/*.o
 	rm -f simple_example
 	rm -f jsondump
-	rm -f test/test_default test/test_strict test/test_links test/test_strict_links
+	rm -f test/test_default test/test_nonstrict test/test_lowmem test/test_nonstrict_lowmem test/test_permissiveprims test/test_permissivestrs test/test_primkeys
 
 .PHONY: clean test
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ clean:
 	rm -f *.o example/*.o
 	rm -f simple_example
 	rm -f jsondump
+	rm -f test/test_default test/test_strict test/test_links test/test_strict_links
 
 .PHONY: clean test
 

--- a/jsmn.h
+++ b/jsmn.h
@@ -99,7 +99,7 @@ typedef enum {
   JSMN_STATE_OBJ_NEW = (JSMN_KEY | JSMN_CAN_CLOSE),
   /* Just saw a comma in an object. Expecting key. */
   JSMN_STATE_OBJ_KEY = (JSMN_KEY),
-  /* Just saw a key in an object. Expecting colon or maybe close/comma. */
+  /* Just saw a key in an object. Expecting colon. */
   JSMN_STATE_OBJ_COLON = (JSMN_KEY | JSMN_DELIMITER),
   /* Just saw a colon in an object. Expecting value. */
   JSMN_STATE_OBJ_VAL = (JSMN_VALUE),

--- a/jsmn.h
+++ b/jsmn.h
@@ -142,7 +142,7 @@ static jsmntok_t *jsmn_alloc_token(jsmn_parser *parser, jsmntok_t *tokens,
   tok->end = 0;
   tok->size = 0;
 #ifdef JSMN_PARENT_LINKS
-  tok->parent = -1;
+  tok->parent = parser->tokbefore;
 #endif
   return tok;
 }
@@ -429,7 +429,7 @@ static int jsmn_parse_string(jsmn_parser *parser, const char *js,
     if (c == '\\' && parser->pos + 1 < len) {
       int i;
       parser->pos++;
-#ifndef JSMN_STRICT
+#ifdef JSMN_STRICT
       switch (js[parser->pos]) {
       /* Allowed escaped symbols */
       case '\"':

--- a/jsmn.h
+++ b/jsmn.h
@@ -208,7 +208,7 @@ static int jsmn_parse_primitive(jsmn_parser *parser, const char *js,
 #ifdef JSMN_STRICT
   if (js[parser->pos] == 't') {
     for (i = 1;
-         i < strlen(true_str);
+         i < sizeof(true_str) - 1;
          i++) {
       if (parser->pos + i >= len || js[parser->pos + i] == '\0') {
         return JSMN_ERROR_PART;
@@ -219,7 +219,7 @@ static int jsmn_parse_primitive(jsmn_parser *parser, const char *js,
     parser->pos += 4;
   } else if (js[parser->pos] == 'f') {
     for (i = 1;
-         i < strlen(false_str);
+         i < sizeof(false_str) - 1;
          i++) {
       if (parser->pos + i >= len || js[parser->pos + i] == '\0') {
         return JSMN_ERROR_PART;
@@ -230,7 +230,7 @@ static int jsmn_parse_primitive(jsmn_parser *parser, const char *js,
     parser->pos += 5;
   } else if (js[parser->pos] == 'n') {
     for (i = 1;
-         i < strlen(null_str);
+         i < sizeof(null_str) - 1;
          i++) {
       if (parser->pos + i >= len || js[parser->pos + i] == '\0') {
         return JSMN_ERROR_PART;

--- a/jsmn.h
+++ b/jsmn.h
@@ -407,15 +407,20 @@ container_close:
         return r;
       }
       count++;
+      if (tokens == NULL) {
+        if (depth == 0) {
+          return count;
+        } else {
+          break;
+        }
+      }
       if (parser->toksuper == -1) {
         return count;
-      } else if (tokens != NULL) {
-        if (parser->state & 0x1) {
-          return JSMN_ERROR_INVAL;
-        }
-        parser->state++;
-        tokens[parser->toksuper].size++;
+      } else if (parser->state & 0x1) {
+        return JSMN_ERROR_INVAL;
       }
+      parser->state++;
+      tokens[parser->toksuper].size++;
       break;
     case '\t':
     case '\r':
@@ -475,19 +480,24 @@ container_close:
         return r;
       }
       count++;
+      if (tokens == NULL) {
+        if (depth == 0) {
+          return count;
+        } else {
+          break;
+        }
+      }
       if (parser->toksuper == -1) {
         return count;
-      } else if (tokens != NULL) {
 #ifdef JSMN_STRICT
-        if (parser->state & 0x3) {
+      } else if (parser->state & 0x3) {
 #else
-        if (parser->state & 0x1) {
+      } else if (parser->state & 0x1) {
 #endif
-          return JSMN_ERROR_INVAL;
-        }
-        parser->state++;
-        tokens[parser->toksuper].size++;
+        return JSMN_ERROR_INVAL;
       }
+      parser->state++;
+      tokens[parser->toksuper].size++;
       break;
 #ifdef JSMN_STRICT
     /* Unexpected char in strict mode */

--- a/jsmn.h
+++ b/jsmn.h
@@ -99,7 +99,7 @@ typedef enum {
   JSMN_STATE_OBJ_COMMA = 0x15,    /* Expecting object comma or } */
   JSMN_STATE_ARRAY_NEW = 0x24,    /* Expecting array item or ] */
   JSMN_STATE_ARRAY_ITEM = 0x20,   /* Expecting array item */
-  JSMN_STATE_ARRAY_COMMA = 0x25,  /* Expecting array comma or ] */
+  JSMN_STATE_ARRAY_COMMA = 0x25   /* Expecting array comma or ] */
 } jsmnstate_t;
 
 /**
@@ -158,9 +158,9 @@ static void jsmn_fill_token(jsmntok_t *token, const jsmntype_t type,
 }
 
 #ifdef JSMN_STRICT
-static char true_str[] = "true";
-static char false_str[] = "false";
-static char null_str[] = "null";
+static const char true_str[] = "true";
+static const char false_str[] = "false";
+static const char null_str[] = "null";
 
 typedef enum {
   JSMN_NUM_INT_START,

--- a/jsmn.h
+++ b/jsmn.h
@@ -98,7 +98,7 @@ typedef enum {
   JSMN_STATE_OBJ_KEY = 0x12,      /* Expecting object key */
   JSMN_STATE_OBJ_COLON = 0x13,    /* Expecting object colon */
   JSMN_STATE_OBJ_VAL = 0x10,      /* Expecting object value */
-  JSMN_STATE_OBJ_COMMA = 0x11     /* Expecting object comma or } */
+  JSMN_STATE_OBJ_COMMA = 0x11,    /* Expecting object comma or } */
   JSMN_STATE_ARRAY_ITEM = 0x20,   /* Expecting array item */
   JSMN_STATE_ARRAY_COMMA = 0x21,  /* Expecting array comma or ] */
 } jsmnstate_t;
@@ -369,7 +369,7 @@ JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
           return count;
         }
         break;
-      } else if (jsmn->state != JSMN_STATE_OBJ_COMMA) {
+      } else if (parser->state != JSMN_STATE_OBJ_COMMA) {
         return JSMN_ERROR_INVAL;
       }
       goto container_close;
@@ -380,7 +380,7 @@ JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
           return count;
         }
         break;
-      } else if (jsmn->state != JSMN_STATE_ARRAY_COMMA) {
+      } else if (parser->state != JSMN_STATE_ARRAY_COMMA) {
         return JSMN_ERROR_INVAL;
       }
 container_close:
@@ -399,7 +399,7 @@ container_close:
       if (parser->toksuper == -1) {
         return count;
       } else {
-        jsmn->state = tokens[parser->toksuper].type << 4 & 0x1;
+        parser->state = tokens[parser->toksuper].type << 4 & 0x1;
       }
     case '\"':
       r = jsmn_parse_string(parser, js, len, tokens, num_tokens);
@@ -408,7 +408,7 @@ container_close:
       }
       count++;
       if (tokens == NULL) {
-        if (depth == 0) {
+        if (parser->depth == 0) {
           return count;
         } else {
           break;
@@ -481,7 +481,7 @@ container_close:
       }
       count++;
       if (tokens == NULL) {
-        if (depth == 0) {
+        if (parser->depth == 0) {
           return count;
         } else {
           break;

--- a/jsmn.h
+++ b/jsmn.h
@@ -429,6 +429,7 @@ static int jsmn_parse_string(jsmn_parser *parser, const char *js,
     if (c == '\\' && parser->pos + 1 < len) {
       int i;
       parser->pos++;
+#ifndef JSMN_STRICT
       switch (js[parser->pos]) {
       /* Allowed escaped symbols */
       case '\"':
@@ -461,7 +462,16 @@ static int jsmn_parse_string(jsmn_parser *parser, const char *js,
         parser->pos = start;
         return JSMN_ERROR_INVAL;
       }
+#endif
     }
+
+#ifdef JSMN_STRICT
+    /* No control characters allowed in strict mode */
+    if (c >= 0 && c < 32) {
+      parser->pos = start;
+      return JSMN_ERROR_INVAL;
+    }
+#endif
   }
   parser->pos = start;
   return JSMN_ERROR_PART;

--- a/jsmn.h
+++ b/jsmn.h
@@ -44,13 +44,13 @@ extern "C" {
 #endif
 
 #ifdef JSMN_NON_STRICT
-#ifndef
+#ifndef JSMN_PERMISSIVE_PRIMITIVES
 #define JSMN_PERMISSIVE_PRIMITIVES
 #endif
-#ifndef
+#ifndef JSMN_PERMISSIVE_STRINGS
 #define JSMN_PERMISSIVE_STRINGS
 #endif
-#ifndef
+#ifndef JSMN_PRIMITIVE_KEYS
 #define JSMN_PRIMITIVE_KEYS
 #endif
 #endif

--- a/test/tests.c
+++ b/test/tests.c
@@ -125,7 +125,6 @@ int test_partial_string(void) {
 }
 
 int test_partial_array(void) {
-#ifdef JSMN_STRICT
   int r;
   unsigned long i;
   jsmn_parser p;
@@ -144,7 +143,6 @@ int test_partial_array(void) {
       check(r == JSMN_ERROR_PART);
     }
   }
-#endif
   return 0;
 }
 

--- a/test/tests.c
+++ b/test/tests.c
@@ -33,28 +33,34 @@ int test_object(void) {
 #ifdef JSMN_STRICT
   check(parse("{\"a\"\n0}", JSMN_ERROR_INVAL, 3));
   check(parse("{\"a\", 0}", JSMN_ERROR_INVAL, 3));
-  check(parse("{\"a\": {2}}", JSMN_ERROR_INVAL, 3));
-  check(parse("{\"a\": {2: 3}}", JSMN_ERROR_INVAL, 3));
-  check(parse("{\"a\": {\"a\": 2 3}}", JSMN_ERROR_INVAL, 5));
-/* FIXME */
-/*check(parse("{\"a\"}", JSMN_ERROR_INVAL, 2));*/
-/*check(parse("{\"a\": 1, \"b\"}", JSMN_ERROR_INVAL, 4));*/
-/*check(parse("{\"a\",\"b\":1}", JSMN_ERROR_INVAL, 4));*/
-/*check(parse("{\"a\":1,}", JSMN_ERROR_INVAL, 4));*/
-/*check(parse("{\"a\":\"b\":\"c\"}", JSMN_ERROR_INVAL, 4));*/
-/*check(parse("{,}", JSMN_ERROR_INVAL, 4));*/
+  check(parse("{\"a\": {2}}", JSMN_ERROR_INVAL, 4));
+  check(parse("{\"a\": {2: 3}}", JSMN_ERROR_INVAL, 5));
+  check(parse("{\"a\": {\"a\": 2 3}}", JSMN_ERROR_INVAL, 6));
+  check(parse("{\"a\"}", JSMN_ERROR_INVAL, 2));
+  check(parse("{\"a\": 1, \"b\"}", JSMN_ERROR_INVAL, 4));
+  check(parse("{\"a\",\"b\":1}", JSMN_ERROR_INVAL, 4));
+  check(parse("{\"a\":1,}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"a\":\"b\":\"c\"}", JSMN_ERROR_INVAL, 4));
+  check(parse("{,}", JSMN_ERROR_INVAL, 1));
+  check(parse("{\"a\":}", JSMN_ERROR_INVAL, 2));
+  check(parse("{\"a\" \"b\"}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"a\" ::::: \"b\"}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"a\": [1 \"b\"]}", JSMN_ERROR_INVAL, 5));
+  check(parse("{\"a\"\"\"}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"a\":1\"\"}", JSMN_ERROR_INVAL, 4));
+  check(parse("{\"a\":1\"b\":1}", JSMN_ERROR_INVAL, 5));
+  check(parse("{\"a\":\"b\", \"c\":\"d\", {\"e\": \"f\"}}",
+              JSMN_ERROR_INVAL, 8));
 #endif
   return 0;
 }
 
 int test_array(void) {
-  /* FIXME */
-  /*check(parse("[10}", JSMN_ERROR_INVAL, 3));*/
-  /*check(parse("[1,,3]", JSMN_ERROR_INVAL, 3)*/
+  check(parse("[10}", JSMN_ERROR_INVAL, 3));
+  check(parse("[1,,3]", JSMN_ERROR_INVAL, 3));
   check(parse("[10]", 2, 2, JSMN_ARRAY, -1, -1, 1, JSMN_PRIMITIVE, "10"));
   check(parse("{\"a\": 1]", JSMN_ERROR_INVAL, 3));
-  /* FIXME */
-  /*check(parse("[\"a\": 1]", JSMN_ERROR_INVAL, 3));*/
+  check(parse("[\"a\": 1]", JSMN_ERROR_INVAL, 3));
   return 0;
 }
 
@@ -177,12 +183,13 @@ int test_unquoted_keys(void) {
   const char *js;
 
   jsmn_init(&p);
-  js = "key1: \"value\"\nkey2 : 123";
+  js = "{key1: \"value\", key2 : 123}";
 
   r = jsmn_parse(&p, js, strlen(js), tok, 10);
   check(r >= 0);
-  check(tokeq(js, tok, 4, JSMN_PRIMITIVE, "key1", JSMN_STRING, "value", 0,
-              JSMN_PRIMITIVE, "key2", JSMN_PRIMITIVE, "123"));
+  check(tokeq(js, tok, 5, JSMN_OBJECT, -1, -1, 2, JSMN_PRIMITIVE, "key1",
+              JSMN_STRING, "value", 0, JSMN_PRIMITIVE, "key2",
+              JSMN_PRIMITIVE, "123"));
 #endif
   return 0;
 }
@@ -301,14 +308,15 @@ int test_nonstrict(void) {
 
 int test_unmatched_brackets(void) {
   const char *js;
-  js = "\"key 1\": 1234}";
-  check(parse(js, JSMN_ERROR_INVAL, 2));
+  /* js = "\"key 1\": 1234}";
+  check(parse(js, JSMN_ERROR_INVAL, 2)); */
   js = "{\"key 1\": 1234";
   check(parse(js, JSMN_ERROR_PART, 3));
+  /*
   js = "{\"key 1\": 1234}}";
   check(parse(js, JSMN_ERROR_INVAL, 3));
   js = "\"key 1\"}: 1234";
-  check(parse(js, JSMN_ERROR_INVAL, 3));
+  check(parse(js, JSMN_ERROR_INVAL, 3));*/
   js = "{\"key {1\": 1234}";
   check(parse(js, 3, 3, JSMN_OBJECT, 0, 16, 1, JSMN_STRING, "key {1", 1,
               JSMN_PRIMITIVE, "1234"));
@@ -349,9 +357,9 @@ int main(void) {
   test(test_unquoted_keys, "test unquoted keys (like in JavaScript)");
   test(test_input_length, "test strings that are not null-terminated");
   test(test_issue_22, "test issue #22");
-  test(test_issue_27, "test issue #27");
+  /* test(test_issue_27, "test issue #27"); */
   test(test_count, "test tokens count estimation");
-  test(test_nonstrict, "test for non-strict mode");
+  /* test(test_nonstrict, "test for non-strict mode"); */
   test(test_unmatched_brackets, "test for unmatched brackets");
   test(test_object_key, "test for key type");
   printf("\nPASSED: %d\nFAILED: %d\n", test_passed, test_failed);

--- a/test/tests.c
+++ b/test/tests.c
@@ -387,7 +387,7 @@ int test_unenclosed(void) {
   check(parse(js, 1, 1, JSMN_PRIMITIVE, "fal"));
  
   js = "fal ";
-  check(parse(js, 1, 1, JSMN_PRIMITIVE, "fal "));
+  check(parse(js, 1, 1, JSMN_PRIMITIVE, "fal"));
 #endif
  
   js = "\"a\": 0";
@@ -493,7 +493,7 @@ int main(void) {
   test(test_input_length, "test strings that are not null-terminated");
   test(test_issue_22, "test issue #22");
   test(test_count, "test tokens count estimation");
-  /* test(test_unenclosed, "test for non-strict mode"); */
+   test(test_unenclosed, "test for non-strict mode");
   test(test_unmatched_brackets, "test for unmatched brackets");
   test(test_object_key, "test for key type");
   test(test_multiple_objects, "test parsing multiple items at once");

--- a/test/tests.c
+++ b/test/tests.c
@@ -306,15 +306,15 @@ int test_nonstrict(void) {
 
 int test_unmatched_brackets(void) {
   const char *js;
-  /* js = "\"key 1\": 1234}";
-  check(parse(js, JSMN_ERROR_INVAL, 2)); */
+  js = "\"key 1\": 1234}";
+  check(parse(js, JSMN_ERROR_INVAL, 2));
   js = "{\"key 1\": 1234";
   check(parse(js, JSMN_ERROR_PART, 3));
-  /*
+  
   js = "{\"key 1\": 1234}}";
   check(parse(js, JSMN_ERROR_INVAL, 3));
   js = "\"key 1\"}: 1234";
-  check(parse(js, JSMN_ERROR_INVAL, 3));*/
+  check(parse(js, JSMN_ERROR_INVAL, 3));
   js = "{\"key {1\": 1234}";
   check(parse(js, 3, 3, JSMN_OBJECT, 0, 16, 1, JSMN_STRING, "key {1", 1,
               JSMN_PRIMITIVE, "1234"));
@@ -355,7 +355,7 @@ int main(void) {
   test(test_unquoted_keys, "test unquoted keys (like in JavaScript)");
   test(test_input_length, "test strings that are not null-terminated");
   test(test_issue_22, "test issue #22");
-  /* test(test_issue_27, "test issue #27"); */
+  test(test_issue_27, "test issue #27");
   test(test_count, "test tokens count estimation");
   /* test(test_nonstrict, "test for non-strict mode"); */
   test(test_unmatched_brackets, "test for unmatched brackets");

--- a/test/tests.c
+++ b/test/tests.c
@@ -73,8 +73,54 @@ int test_primitive(void) {
               JSMN_STRING, "nullVar", 1, JSMN_PRIMITIVE, "null"));
   check(parse("{\"intVar\" : 12}", 3, 3, JSMN_OBJECT, -1, -1, 1, JSMN_STRING,
               "intVar", 1, JSMN_PRIMITIVE, "12"));
+  check(parse("{\"intVar\" : 0}", 3, 3, JSMN_OBJECT, -1, -1, 1, JSMN_STRING,
+              "intVar", 1, JSMN_PRIMITIVE, "0"));
   check(parse("{\"floatVar\" : 12.345}", 3, 3, JSMN_OBJECT, -1, -1, 1,
               JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "12.345"));
+  check(parse("{\"floatVar\" : -12.345}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "-12.345"));
+  check(parse("{\"floatVar\" : 0.345}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "0.345"));
+  check(parse("{\"floatVar\" : 12.345e6}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "12.345e6"));
+  check(parse("{\"floatVar\" : 12.345E+6}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "12.345E+6"));
+  check(parse("{\"floatVar\" : 12e+6}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "12e+6"));
+
+#ifdef JSMN_STRICT
+  check(parse("{\"boolVar\" : tru }", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"boolVar\" : falsee }", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"nullVar\" : nulm }", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"intVar\" : 01}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"floatVar\" : .345}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"floatVar\" : -}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"floatVar\" : 12.}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"floatVar\" : 12.}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"floatVar\" : +12}", JSMN_ERROR_INVAL, 3));
+  check(parse("{\"floatVar\" : 12.345e-}", JSMN_ERROR_INVAL, 3));
+#else
+  check(parse("{\"boolVar\" : tru }", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "boolVar", 1, JSMN_PRIMITIVE, "tru"));
+  check(parse("{\"boolVar\" : falsee }", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "boolVar", 1, JSMN_PRIMITIVE, "falsee"));
+  check(parse("{\"nullVar\" : nulm }", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "nullVar", 1, JSMN_PRIMITIVE, "nulm"));
+  check(parse("{\"intVar\" : 01}", 3, 3, JSMN_OBJECT, -1, -1, 1, JSMN_STRING,
+              "intVar", 1, JSMN_PRIMITIVE, "01"));
+  check(parse("{\"floatVar\" : .345}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, ".345"));
+  check(parse("{\"floatVar\" : -}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "-"));
+  check(parse("{\"floatVar\" : 12.}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "12."));
+  check(parse("{\"floatVar\" : 12.}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "12."));
+  check(parse("{\"floatVar\" : +12}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "+12"));
+  check(parse("{\"floatVar\" : 12.345e-}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "floatVar", 1, JSMN_PRIMITIVE, "12.345e-"));
+#endif
   return 0;
 }
 
@@ -95,10 +141,26 @@ int test_string(void) {
   check(parse("{\"a\":[\"\\u0280\"]}", 4, 4, JSMN_OBJECT, -1, -1, 1,
               JSMN_STRING, "a", 1, JSMN_ARRAY, -1, -1, 1, JSMN_STRING,
               "\\u0280", 0));
+  /* \xc2\xa9 is the copyright symbol in UTF-8 */
+  check(parse("{\"a\":\"str\xc2\xa9\"}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "a", 1, JSMN_STRING, "str\xc2\xa9", 0));
 
+#ifdef JSMN_STRICT
+  check(parse("{\"a\":\"str\nstr\"}", JSMN_ERROR_INVAL, 3));
   check(parse("{\"a\":\"str\\uFFGFstr\"}", JSMN_ERROR_INVAL, 3));
   check(parse("{\"a\":\"str\\u@FfF\"}", JSMN_ERROR_INVAL, 3));
-  check(parse("{{\"a\":[\"\\u028\"]}", JSMN_ERROR_INVAL, 4));
+  check(parse("{\"a\":[\"\\u028\"]}", JSMN_ERROR_INVAL, 4));
+#else
+  check(parse("{\"a\":\"str\nstr\"}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "a", 1, JSMN_STRING, "str\nstr", 0));
+  check(parse("{\"a\":\"str\\uFFGFstr\"}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "a", 1, JSMN_STRING, "str\\uFFGFstr", 0));
+  check(parse("{\"a\":\"str\\u@FfF\"}", 3, 3, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "a", 1, JSMN_STRING, "str\\u@FfF", 0));
+  check(parse("{\"a\":[\"\\u028\"]}", 4, 4, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "a", 1, JSMN_ARRAY, -1, -1, 1,
+              JSMN_STRING, "\\u028", 0));
+#endif
   return 0;
 }
 
@@ -215,13 +277,6 @@ int test_issue_22(void) {
   return 0;
 }
 
-int test_issue_27(void) {
-  const char *js =
-      "{ \"name\" : \"Jack\", \"age\" : 27 } { \"name\" : \"Anna\", ";
-  check(parse(js, JSMN_ERROR_PART, 8));
-  return 0;
-}
-
 int test_input_length(void) {
   const char *js;
   int r;
@@ -285,9 +340,64 @@ int test_count(void) {
   return 0;
 }
 
-int test_nonstrict(void) {
-#ifndef JSMN_STRICT
+int test_unenclosed(void) {
   const char *js;
+  js = "1234";
+  check(parse(js, 1, 1, JSMN_PRIMITIVE, "1234"));
+
+  js = "false";
+  check(parse(js, 1, 1, JSMN_PRIMITIVE, "false"));
+ 
+  js = "0garbage";
+#ifdef JSMN_STRICT
+  check(parse(js, JSMN_ERROR_INVAL, 1));
+#else
+  check(parse(js, 1, 1, JSMN_PRIMITIVE, "0garbage"));
+#endif
+
+  js = "\"0garbage\"";
+  check(parse(js, 1, 1, JSMN_STRING, "0garbage", 0));
+
+  js = "\"0garbage";
+  check(parse(js, JSMN_ERROR_PART, 1));
+
+  js = "1234\"0garbage\"";
+  check(parse(js, 2, 2, JSMN_PRIMITIVE, "1234", JSMN_STRING, "0garbage", 0));
+
+  js = "\"0garbage\"1234";
+  check(parse(js, 2, 2, JSMN_STRING, "0garbage", 0, JSMN_PRIMITIVE, "1234"));
+
+  js = " 1234";
+  check(parse(js, 1, 1, JSMN_PRIMITIVE, "1234"));
+
+  js = "1234 ";
+  check(parse(js, 1, 1, JSMN_PRIMITIVE, "1234"));
+
+  js = " 1234 ";
+  check(parse(js, 1, 1, JSMN_PRIMITIVE, "1234"));
+
+#ifdef JSMN_STRICT
+  js = "fal";
+  check(parse(js, JSMN_ERROR_PART, 1));
+ 
+  js = "fal ";
+  check(parse(js, JSMN_ERROR_INVAL, 1));
+#else
+  js = "fal";
+  check(parse(js, 1, 1, JSMN_PRIMITIVE, "fal"));
+ 
+  js = "fal ";
+  check(parse(js, 1, 1, JSMN_PRIMITIVE, "fal "));
+#endif
+ 
+  js = "\"a\": 0";
+  check(parse(js, JSMN_ERROR_INVAL, 2));
+
+  js = "\"a\", 0";
+  check(parse(js, JSMN_ERROR_INVAL, 2));
+
+  /* XXX No longer valid after RFC 8259 fixes
+#ifndef JSMN_STRICT
   js = "a: 0garbage";
   check(parse(js, 2, 2, JSMN_PRIMITIVE, "a", JSMN_PRIMITIVE, "0garbage"));
 
@@ -295,12 +405,14 @@ int test_nonstrict(void) {
   check(parse(js, 6, 6, JSMN_PRIMITIVE, "Day", JSMN_PRIMITIVE, "26",
               JSMN_PRIMITIVE, "Month", JSMN_PRIMITIVE, "Sep", JSMN_PRIMITIVE,
               "Year", JSMN_PRIMITIVE, "12"));
+  */
 
   /* nested {s don't cause a parse error. */
+  /* XXX No longer valid after RFC 8259 fixes
   js = "\"key {1\": 1234";
   check(parse(js, 2, 2, JSMN_STRING, "key {1", 1, JSMN_PRIMITIVE, "1234"));
-
 #endif
+  */
   return 0;
 }
 
@@ -342,6 +454,31 @@ int test_object_key(void) {
   return 0;
 }
 
+int test_multiple_objects(void) {
+  const char *js;
+  js = "true {\"def\": 123}";
+  check(parse(js, 4, 4, JSMN_PRIMITIVE, "true", JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "def", 1, JSMN_PRIMITIVE, "123"));
+
+  js = "{\"def\": 123} true";
+  check(parse(js, 4, 4, JSMN_OBJECT, -1, -1, 1, JSMN_STRING, "def", 1,
+              JSMN_PRIMITIVE, "123", JSMN_PRIMITIVE, "true"));
+
+  js = "true{\"def\": 123}";
+  check(parse(js, 4, 4, JSMN_PRIMITIVE, "true", JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "def", 1, JSMN_PRIMITIVE, "123"));
+
+  js = "[true, \"abc\"]{\"def\": 123}";
+  check(parse(js, 6, 6, JSMN_ARRAY, -1, -1, 2, JSMN_PRIMITIVE, "true",
+              JSMN_STRING, "abc", 0, JSMN_OBJECT, -1, -1, 1,
+              JSMN_STRING, "def", 1, JSMN_PRIMITIVE, "123"));
+
+  /* Issue #27 */
+  js = "{ \"name\" : \"Jack\", \"age\" : 27 } { \"name\" : \"Anna\", ";
+  check(parse(js, JSMN_ERROR_PART, 8));
+  return 0;
+}
+
 int main(void) {
   test(test_empty, "test for a empty JSON objects/arrays");
   test(test_object, "test for a JSON objects");
@@ -355,11 +492,11 @@ int main(void) {
   test(test_unquoted_keys, "test unquoted keys (like in JavaScript)");
   test(test_input_length, "test strings that are not null-terminated");
   test(test_issue_22, "test issue #22");
-  test(test_issue_27, "test issue #27");
   test(test_count, "test tokens count estimation");
-  /* test(test_nonstrict, "test for non-strict mode"); */
+  /* test(test_unenclosed, "test for non-strict mode"); */
   test(test_unmatched_brackets, "test for unmatched brackets");
   test(test_object_key, "test for key type");
+  test(test_multiple_objects, "test parsing multiple items at once");
   printf("\nPASSED: %d\nFAILED: %d\n", test_passed, test_failed);
   return (test_failed > 0);
 }


### PR DESCRIPTION
### This PR does two things:
- Create more granular macros for specific non-strict features
- Enable strict mode and parent links by default

### Details

#### More granular macros

**This PR builds on the changes from PR #194.** With PR #194, there are three specific ways in which non-strict mode diverges from RFC 8259:

1. Primitives may contain any character except whitespace and those with special meaning in JSON (`{}[],:"`).
2. Strings may contain control characters (`\x01` - `\x1F`) and invalid escape sequences
3. Primitives may be used as object keys

Some projects using jsmn might want some of these features, but not all. For example, a project might want to enable (1) to improve performance or shrink code size, but leave (3) disabled to help catch bugs.

For this purpose, this PR creates three new macros: `JSMN_PERMISSIVE_PRIMITIVES` for (1), `JSMN_PERMISSIVE_STRINGS` for (2), and `JSMN_PRIMITIVE_KEYS` for (3). These can be defined individually, or defining `JSMN_NON_STRICT` will cause all to be defined.

#### Enable strict mode and parent links by default

With this PR, strict RFC 8259 compliance and parent links become the default behavior. New macros `JSMN_LOW_MEMORY` and `JSMN_NON_STRICT` disable these behaviors.

`JSMN_PARENT_LINKS` still exists, but is defined by default unless `JSMN_LOW_MEMORY` is defined.

`JSMN_NON_STRICT` replaces `JSMN_STRICT`. When defined, all non-strict features are enabled.