### PR TITLE
Allow JSMN_API to be defined by the user (e. g. for Windows DLLs).

### DIFF
--- a/jsmn.h
+++ b/jsmn.h
@@ -30,10 +30,12 @@
 extern "C" {
 #endif
 
-#ifdef JSMN_STATIC
-#define JSMN_API static
-#else
-#define JSMN_API extern
+#ifndef JSMN_API
+#  ifdef JSMN_STATIC
+#     define JSMN_API static
+#  else
+#     define JSMN_API extern
+#  endif
 #endif
 
 /**


### PR DESCRIPTION
To make jsmn part of a shared Windows-DLL, jsmn's functions have to be marked `__declspec(dllexport)` / `__declscpec(dllimport)`. Functions marked as `extern` are - contrary to unix - not automatically exported.

Making `JSMN_API` user-definable (with a default fallback)  makes writing wrapper such as these possible:

**jsmn_dll_wrapper.c:**
```c
#ifdef _WIN32
#   define JSMN_API __declspec(dllexport)
#endif
#define JSMN_STRICT
#include "jsmn.h"
```

**jsmn_dll_wrapper.h**
``` c
#ifdef _WIN32
#  ifdef EXPORTS
#     define JSMN_API __declspec(dllexport)
#  else
#     define JSMN_API __declspec(dllimport)
#  endif
#endif
#define JSMN_HEADER
#include "jsmn.h"
#undef JSMN_HEADER
```