### PR TITLE
Add fuzzer

### DIFF
--- a/test/fuzzer.c
+++ b/test/fuzzer.c
@@ -1,0 +1,24 @@
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include "../jsmn.h"
+
+extern "C"
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+        char *js = (char *)malloc(size+1);
+        if (js == NULL){
+                return 0;
+        }
+        memcpy(js, data, size);
+        js[size] = '\0';
+
+        int r;
+        jsmn_parser p;
+        jsmntok_t tokens[128];
+        jsmn_init(&p);
+        r = jsmn_parse(&p, js, strlen(js), tokens, 128);
+
+
+        free(js);
+        return 0;
+}


### PR DESCRIPTION
Adds a fuzzer that tests `jsmn_parse()`.

I recommend running the fuzzer in the CI with [ClusterfuzzLite](https://google.github.io/clusterfuzzlite/). Since jsmn does not have any Github workflows, I didn't add that part, but I have tested it locally and will be happy to set it up in the CI.

Signed-off-by: AdamKorcz <Adam@adalogics.com>