### PR TITLE
JSMN_TOKNEXT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ simple_example: example/simple.c jsmn.h
 jsondump: example/jsondump.c jsmn.h
 	$(CC) $(LDFLAGS) $< -o $@
 
+tokendump: example/tokendump.c jsmn.h
+	$(CC) $(LDFLAGS) $< -o $@
+
 fmt:
 	clang-format -i jsmn.h test/*.[ch] example/*.[ch]
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ clean:
 	rm -f *.o example/*.o
 	rm -f simple_example
 	rm -f jsondump
+	rm -f tokendump
 
 .PHONY: clean test
 

--- a/example/tokendump.c
+++ b/example/tokendump.c
@@ -1,0 +1,76 @@
+#define JSMN_TOKNEXT
+
+#include "../jsmn.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void dump(char *js, jsmntok_t* tokens) {
+  int tokenCount = tokens[0].toknext;
+  for (int ti = 0; ti < tokenCount; ti++) {
+    jsmntok_t t = tokens[ti];
+    char *type;
+    switch (t.type) {
+    case JSMN_ARRAY:
+      type = "ARRAY";
+      break;
+    case JSMN_OBJECT:
+      type = "OBJECT";
+      break;
+    case JSMN_PRIMITIVE:
+      type = "PRIMITIVE";
+      break;
+    case JSMN_STRING:
+      type = "STRING";
+      break;
+    }
+    printf("%3d: %9s[%03d]: %4d-%4d: %3d", ti, type, t.size, t.start, t.end,
+           t.toknext);
+    switch (t.type) {
+    case JSMN_PRIMITIVE:
+    case JSMN_STRING:
+      printf(": ");
+      for (int i = t.start; i < t.end;)
+        putchar(js[i++]);
+    }
+    putchar('\n');
+  }
+}
+
+void help() {
+  puts("tokendump <json>");
+  exit(1);
+}
+
+int main(int argc, char *args[]) {
+  if (argc != 2)
+    help();
+  FILE *f = fopen(args[1], "r");
+  if (f == NULL)
+    help();
+
+  // load file to memory
+  fseek(f, 0, SEEK_END);
+  long size = ftell(f);
+  fseek(f, 0, SEEK_SET);
+  char *js = malloc(size + 1);
+  for (int i = 0; i < size;)
+    js[i++] = fgetc(f);
+  js[size] = 0;
+  fclose(f);
+
+  // count tokens first
+  jsmn_parser parser;
+  jsmn_init(&parser);
+  int len = strlen(js);
+  int tokenCount = jsmn_parse(&parser, js, len, NULL, -1);
+  if (tokenCount > 0) {
+    // parse them
+    jsmntok_t *tokens = malloc(tokenCount * sizeof(jsmntok_t));
+    jsmn_init(&parser);
+    jsmn_parse(&parser, (const char *)js, len, tokens, tokenCount);
+    // and dump finally
+    dump(js, tokens);
+  }
+}

--- a/example/tokendump.c
+++ b/example/tokendump.c
@@ -27,8 +27,8 @@ void dump(char *js, jsmntok_t* tokens) {
       type = "STRING";
       break;
     }
-    printf("%3d: %9s[%03d]: %4d-%4d: %3d", ti, type, t.size, t.start, t.end,
-           t.toknext);
+    printf("%3d: %9s[%03d]: %4d-%4d: %4d", ti, type, t.size, t.start, t.end,
+           jsmn_next_token(tokens, tokenCount, ti));
     switch (t.type) {
     case JSMN_PRIMITIVE:
     case JSMN_STRING:

--- a/example/tokendump.c
+++ b/example/tokendump.c
@@ -1,4 +1,4 @@
-#define JSMN_TOKNEXT
+//#define JSMN_TOKNEXT
 
 #include "../jsmn.h"
 
@@ -6,10 +6,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-void dump(char *js, jsmntok_t* tokens) {
+void dump(char *js, jsmntok_t* tokens, int tokenCount) {
   puts("index    type[size] start-end toknext value");
   puts("-------------------------------------------");
-  int tokenCount = tokens[0].toknext;
   for (int ti = 0; ti < tokenCount; ti++) {
     jsmntok_t t = tokens[ti];
     char *type;
@@ -73,6 +72,6 @@ int main(int argc, char *args[]) {
     jsmn_init(&parser);
     jsmn_parse(&parser, (const char *)js, len, tokens, tokenCount);
     // and dump finally
-    dump(js, tokens);
+    dump(js, tokens, tokenCount);
   }
 }

--- a/example/tokendump.c
+++ b/example/tokendump.c
@@ -7,6 +7,8 @@
 #include <string.h>
 
 void dump(char *js, jsmntok_t* tokens) {
+  puts("index    type[size] start-end toknext value");
+  puts("-------------------------------------------");
   int tokenCount = tokens[0].toknext;
   for (int ti = 0; ti < tokenCount; ti++) {
     jsmntok_t t = tokens[ti];

--- a/jsmn.h
+++ b/jsmn.h
@@ -71,6 +71,9 @@ typedef struct jsmntok {
   int start;
   int end;
   int size;
+#ifdef JSMN_TOKNEXT
+  int toknext;
+#endif
 #ifdef JSMN_PARENT_LINKS
   int parent;
 #endif
@@ -112,6 +115,9 @@ static jsmntok_t *jsmn_alloc_token(jsmn_parser *parser, jsmntok_t *tokens,
   tok = &tokens[parser->toknext++];
   tok->start = tok->end = -1;
   tok->size = 0;
+#ifdef JSMN_TOKNEXT
+	tok->toknext = 0;
+#endif
 #ifdef JSMN_PARENT_LINKS
   tok->parent = -1;
 #endif
@@ -342,7 +348,10 @@ JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
           }
           parser->toksuper = -1;
           token->end = parser->pos + 1;
-          break;
+#ifdef JSMN_TOKNEXT
+          token->toknext = parser->toknext;
+#endif
+        break;
         }
       }
       /* Error if unmatched closing bracket */

--- a/jsmn.h
+++ b/jsmn.h
@@ -69,11 +69,15 @@ enum jsmnerr {
 typedef struct jsmntok {
   jsmntype_t type;
   int start;
-  int end;
-  int size;
 #ifdef JSMN_TOKNEXT
-  int toknext;
+  union {
+    int end;
+    int toknext;
+  };
+#else
+  int end;
 #endif
+  int size;
 #ifdef JSMN_PARENT_LINKS
   int parent;
 #endif
@@ -115,9 +119,6 @@ static jsmntok_t *jsmn_alloc_token(jsmn_parser *parser, jsmntok_t *tokens,
   tok = &tokens[parser->toknext++];
   tok->start = tok->end = -1;
   tok->size = 0;
-#ifdef JSMN_TOKNEXT
-	tok->toknext = 0;
-#endif
 #ifdef JSMN_PARENT_LINKS
   tok->parent = -1;
 #endif


### PR DESCRIPTION
When traversing JSON array or object, it is good to know where the given structure ends.

For this reason, I added the compiler directive JSMN_TOKNEXT, which adds information about the next token.

For clarity, I added a tokendump example:

```
make tokendump
./tokendump library.json
index    type[size] start-end toknext value
-------------------------------------------
  0:    OBJECT[008]:    0- 367:  22
  1:    STRING[001]:    5-   9:   0: name
  2:    STRING[000]:   13-  17:   0: jsmn
  3:    STRING[001]:   23-  31:   0: keywords
  4:    STRING[000]:   35-  39:   0: json
  5:    STRING[001]:   45-  56:   0: description
  6:    STRING[000]:   60- 171:   0: Minimalistic JSON parser/tokenizer in C. It can be easily integrated into resource-limited or embedded projects
  7:    STRING[001]:  177- 187:   0: repository
  8:    OBJECT[002]:  192- 264:  13
  9:    STRING[001]:  199- 203:   0: type
 10:    STRING[000]:  207- 210:   0: git
 11:    STRING[001]:  218- 221:   0: url
 12:    STRING[000]:  225- 259:   0: https://github.com/zserge/jsmn.git
 13:    STRING[001]:  269- 279:   0: frameworks
 14:    STRING[000]:  283- 284:   0: *
 15:    STRING[001]:  290- 299:   0: platforms
 16:    STRING[000]:  303- 304:   0: *
 17:    STRING[001]:  310- 318:   0: examples
 18:     ARRAY[001]:  321- 344:  20
 19:    STRING[000]:  328- 339:   0: example/*.c
 20:    STRING[001]:  349- 356:   0: exclude
 21:    STRING[000]:  360- 364:   0: test
```
