### PR TITLE
Enable use of jsmn as a git submodule in other git projects using CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+
+# This CMakeLists.txt file is used to import the jsmn library into your CMake based project.
+# Use the add_subdirectory command to include this directory in your build and include jsmn in your target_link_libraries command.
+# For example
+# add_subdirectory(jsmn build) will import the jsmn library into your projects CMake build system.
+# target_link_libraries(example jsmn) will link the jsmn library to your example target.
+# You can then use #include "jsmn.h" in your source files to include the jsmn library.
+
+add_library(jsmn INTERFACE)
+
+target_include_directories(jsmn INTERFACE
+  ${CMAKE_CURRENT_LIST_DIR}
+)

--- a/README.md
+++ b/README.md
@@ -172,6 +172,35 @@ If you get `JSMN_ERROR_NOMEM`, you can re-allocate more tokens and call
 periodically call `jsmn_parse` and check if return value is `JSMN_ERROR_PART`.
 You will get this error until you reach the end of JSON data.
 
+
+Git Submodule in CMake Projects
+-------------------------------
+
+The jsmn library can be integrated into a CMake project as a git submodule 
+using the CMakeLists.txt file provided in the jsmn repository.
+
+Your project must first be initialized with git:
+
+	git init
+
+Then, add the jsmn library as a submodule of your project:
+
+	git submodule add https://github.com/zserge/jsmn.git
+
+Next, update the submodules:
+
+	git submodule update --init --recursive
+
+Finally, include the jsmn library in your CMakeLists.txt file with the 
+add_subdirectory and target_link_libraries commands:
+
+	add_subdirectory(jsmn build)
+	target_link_libraries(my_project jsmn)
+
+You can then use #include "jsmn.h" in your source files to include the
+jsmn library and begin using the jsmn library.
+
+
 Other info
 ----------
 


### PR DESCRIPTION
This is not a change to jsmn or the jsmn build system, this adds a CMakeLists.txt file and some documentation in the README.md to enable the use of the jsmn project repository as a git submodule in other git projects that use CMake.

As an example, https://github.com/bnielsen1965/pico-json-reader.git is a git project that uses CMake as the build system and includes jsmn as a git submodule.

NOTE: The pico-json-reader.git project is using the jsmn fork but theoretically would use the jsmn git project if it included the CMakeLists.txt file that enables adding the jsmn submodule into the parent projects CMake build.